### PR TITLE
fix: replace 'slice' by 'cut' in help information

### DIFF
--- a/cmd/chisel/cmd_help.go
+++ b/cmd/chisel/cmd_help.go
@@ -158,7 +158,7 @@ var helpCategories = []helpCategory{{
 }, {
 	Label:       "Action",
 	Description: "make things happen",
-	Commands:    []string{"slice"},
+	Commands:    []string{"cut"},
 }}
 
 var (


### PR DESCRIPTION
Currently:

```bash
$ chisel help
Chisel can slice a Linux distribution using a release database
and construct a new filesystem using the finely defined parts.

Usage: chisel <command> [<options>...]

Commands can be classified as follows:

   Basic: help, version
  Action: slice

For more information about a command, run 'chisel help <command>'.
For a short summary of all commands, run 'chisel help --all'.
```

The text "  Action: slice" is wrong, and should be "  Action: cut".

This is fixed in this PR