### PR TITLE
Chisel can build on top of already chiseled output

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -77,9 +77,18 @@ func (cmd *cmdCut) Execute(args []string) error {
 		return err
 	}
 
+	err = setup.ReadInstalledSlices(cmd.RootDir)
+	if err != nil {
+		return err
+	}
+
 	selection, err := setup.Select(release, sliceKeys)
 	if err != nil {
 		return err
+	}
+
+	if len(selection.Slices) == 0 {
+		return nil
 	}
 
 	archives := make(map[string]archive.Archive)
@@ -98,11 +107,17 @@ func (cmd *cmdCut) Execute(args []string) error {
 		archives[archiveName] = openArchive
 	}
 
-	return slicer.Run(&slicer.RunOptions{
+	err = slicer.Run(&slicer.RunOptions{
 		Selection: selection,
 		Archives:  archives,
 		TargetDir: cmd.RootDir,
 	})
+	if err != nil {
+		return err
+	}
+
+	err = setup.WriteInstalledSlices(cmd.RootDir, selection.Slices)
+	return err
 
 	return printVersions()
 }

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -77,12 +77,12 @@ func (cmd *cmdCut) Execute(args []string) error {
 		return err
 	}
 
-	err = setup.ReadInstalledSlices(cmd.RootDir)
+	db, err := setup.ReadDB(cmd.RootDir)
 	if err != nil {
 		return err
 	}
 
-	selection, err := setup.Select(release, sliceKeys)
+	selection, err := setup.Select(release, sliceKeys, db)
 	if err != nil {
 		return err
 	}
@@ -116,10 +116,10 @@ func (cmd *cmdCut) Execute(args []string) error {
 		return err
 	}
 
-	err = setup.WriteInstalledSlices(cmd.RootDir, selection.Slices)
+	err = db.WriteInstalledSlices(cmd.RootDir, selection.Slices)
 	return err
 
-	return printVersions()
+	// return printVersions()
 }
 
 // TODO These need testing, and maybe moving into a common file.

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -70,9 +70,12 @@ func createSymlink(o *CreateOptions) error {
 	// check if symlink exists, remove if it does
 	_, err = os.Lstat(o.Path)
 	if err == nil {
-		err = os.Remove(o.Path)
-		if err != nil {
-			return err
+		link, err := os.Readlink(o.Path)
+		if err == nil && link == o.Link {
+			err = os.Remove(o.Path)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return os.Symlink(o.Link, o.Path)

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -67,16 +67,23 @@ func createSymlink(o *CreateOptions) error {
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
-	// check if symlink exists, remove if it does
-	_, err = os.Lstat(o.Path)
+	fileinfo, err := os.Lstat(o.Path)
 	if err == nil {
-		link, err := os.Readlink(o.Path)
-		if err == nil && link == o.Link {
-			err = os.Remove(o.Path)
+		if (fileinfo.Mode() & os.ModeSymlink) != 0 {
+			link, err := os.Readlink(o.Path)
 			if err != nil {
 				return err
 			}
+			if link == o.Link {
+				return nil
+			}
 		}
+		err = os.Remove(o.Path)
+		if err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
 	}
 	return os.Symlink(o.Link, o.Path)
 }

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -67,5 +67,13 @@ func createSymlink(o *CreateOptions) error {
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
+	// check if symlink exists, remove if it does
+	_, err = os.Lstat(o.Path)
+	if err == nil {
+		err = os.Remove(o.Path)
+		if err != nil {
+			return err
+		}
+	}
 	return os.Symlink(o.Link, o.Path)
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -239,6 +239,18 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	return order, nil
 }
 
+func ignoreInstalledSlices(slices []SliceKey) ([]SliceKey) {
+	var pruned []SliceKey
+	for _, slice := range slices {
+		if !IsSliceInstalled(slice) {
+			pruned = append(pruned, slice)
+		} else {
+			logf("Slice \"%v\" is already installed, skipping...", slice)
+		}
+	}
+	return pruned
+}
+
 var fnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){2,})\.yaml$`)
 var snameExp = regexp.MustCompile(`^([a-z](?:-?[a-z0-9]){2,})$`)
 var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){2,})_([a-z](?:-?[a-z0-9]){2,})$`)
@@ -606,8 +618,11 @@ func Select(release *Release, slices []SliceKey) (*Selection, error) {
 	if err != nil {
 		return nil, err
 	}
-	selection.Slices = make([]*Slice, len(sorted))
-	for i, key := range sorted {
+
+	pruned := ignoreInstalledSlices(sorted)
+
+	selection.Slices = make([]*Slice, len(pruned))
+	for i, key := range pruned {
 		selection.Slices[i] = release.Packages[key.Package].Slices[key.Slice]
 	}
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -239,10 +239,10 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	return order, nil
 }
 
-func ignoreInstalledSlices(slices []SliceKey) ([]SliceKey) {
+func ignoreInstalledSlices(slices []SliceKey, db *ChiselDB) ([]SliceKey) {
 	var pruned []SliceKey
 	for _, slice := range slices {
-		if !IsSliceInstalled(slice) {
+		if !db.IsSliceInstalled(slice) {
 			pruned = append(pruned, slice)
 		} else {
 			logf("Slice \"%v\" is already installed, skipping...", slice)
@@ -607,7 +607,7 @@ func stripBase(baseDir, path string) string {
 	return strings.TrimPrefix(path, baseDir+string(filepath.Separator))
 }
 
-func Select(release *Release, slices []SliceKey) (*Selection, error) {
+func Select(release *Release, slices []SliceKey, db *ChiselDB) (*Selection, error) {
 	logf("Selecting slices...")
 
 	selection := &Selection{
@@ -619,7 +619,7 @@ func Select(release *Release, slices []SliceKey) (*Selection, error) {
 		return nil, err
 	}
 
-	pruned := ignoreInstalledSlices(sorted)
+	pruned := ignoreInstalledSlices(sorted, db)
 
 	selection.Slices = make([]*Slice, len(pruned))
 	for i, key := range pruned {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -727,7 +727,7 @@ func (s *S) TestParseRelease(c *C) {
 		}
 
 		if test.selslices != nil {
-			selection, err := setup.Select(release, test.selslices)
+			selection, err := setup.Select(release, test.selslices, &setup.ChiselDB{})
 			if test.selerror != "" {
 				c.Assert(err, ErrorMatches, test.selerror)
 				continue

--- a/internal/setup/slices_db.go
+++ b/internal/setup/slices_db.go
@@ -1,0 +1,73 @@
+package setup
+
+import (
+	"bufio"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+)
+
+const slicesDBPath = "/var/lib/chisel/chisel.db"
+
+// Read and store the slices that have been already installed
+var installedSlices []SliceKey
+
+func ReadInstalledSlices(rootdir string) (error) {
+	file, err := os.Open(path.Join(rootdir, slicesDBPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		sliceKey, err := ParseSliceKey(line)
+		if err != nil {
+			return err
+		}
+		installedSlices = append(installedSlices, sliceKey)
+	}
+
+	return nil
+}
+
+func IsSliceInstalled(slice SliceKey) (bool) {
+	for _, installedSlice := range installedSlices {
+		if reflect.DeepEqual(installedSlice, slice) {
+			return true
+		}
+	}
+	return false
+}
+
+func WriteInstalledSlices(rootdir string, slices []*Slice) (error) {
+	dbPath := path.Join(rootdir, slicesDBPath)
+
+	err := os.MkdirAll(filepath.Dir(dbPath), 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	file, err := os.OpenFile(dbPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	for _, slice := range slices {
+		_, err = writer.WriteString(slice.String() + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/setup/slices_db_test.go
+++ b/internal/setup/slices_db_test.go
@@ -1,0 +1,253 @@
+package setup_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/chisel/internal/archive"
+	"github.com/canonical/chisel/internal/setup"
+	"github.com/canonical/chisel/internal/slicer"
+	"github.com/canonical/chisel/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type testRun struct {
+	summary string
+	arch    string
+	release map[string]string
+	slices  []setup.SliceKey
+	result  map[string]string
+	error   string
+}
+
+var testReleasesOfBaseFiles = map[string]string{
+	"chisel.yaml": `
+		format: chisel-v1
+		archives:
+			ubuntu:
+				version: 22.04
+				components: [main, universe]
+	`,
+	"slices/mydir/base-files.yaml": `
+		package: base-files
+		slices:
+			myslice:
+				contents:
+					/usr/bin/hello:
+					/usr/bin/hallo: {copy: /usr/bin/hello}
+					/bin/hallo:     {symlink: ../usr/bin/hallo}
+					/etc/passwd:    {text: data1}
+					/etc/dir/sub/:  {make: true, mode: 01777}
+			yourslice:
+				contents:
+					/tmp/file1: {text: data1, arch: amd64}
+					/tmp/file2: {text: data1, arch: i386}
+					/tmp/file3: {text: data1, arch: [i386, amd64]}
+					/usr/bin/hello1: {copy: /usr/bin/hello, arch: amd64}
+					/usr/bin/hello2: {copy: /usr/bin/hello, arch: i386}
+					/usr/bin/hello3: {copy: /usr/bin/hello, arch: [i386, amd64]}
+			theirslice:
+				essential:
+					- base-files_yourslice
+				contents:
+					/tmp/file4: {text: data2}
+	`,
+}
+
+var testRuns = []testRun{{
+	summary: "First fresh install of a few slices",
+	slices:  []setup.SliceKey{{"base-files", "myslice"}},
+	release: testReleasesOfBaseFiles,
+	result: map[string]string{
+		"/usr/":                          "dir 0755",
+		"/usr/bin/":                      "dir 0755",
+		"/usr/bin/hello":                 "file 0775 eaf29575",
+		"/usr/bin/hallo":                 "file 0775 eaf29575",
+		"/bin/":                          "dir 0755",
+		"/bin/hallo":                     "symlink ../usr/bin/hallo",
+		"/etc/":                          "dir 0755",
+		"/etc/dir/":                      "dir 0755",
+		"/etc/dir/sub/":                  "dir 01777",
+		"/etc/passwd":                    "file 0644 5b41362b",
+		"/var/":                          "dir 0755",
+		"/var/lib/":                      "dir 0755",
+		"/var/lib/chisel/":               "dir 0755",
+		"/var/lib/chisel/chisel.db":      "file 0755 ce9d2c42",
+	},
+}, {
+	summary: "Second Run, consists of previous slices as well",
+	arch:    "amd64",
+	slices:  []setup.SliceKey{{"base-files", "myslice"}, {"base-files", "yourslice"}},
+	release: testReleasesOfBaseFiles,
+	result: map[string]string{
+		"/tmp/":                          "dir 01777",
+		"/tmp/file1":                     "file 0644 5b41362b",
+		"/tmp/file3":                     "file 0644 5b41362b",
+		"/usr/":                          "dir 0755",
+		"/usr/bin/":                      "dir 0755",
+		"/usr/bin/hello":                 "file 0775 eaf29575",
+		"/usr/bin/hello1":                "file 0775 eaf29575",
+		"/usr/bin/hello3":                "file 0775 eaf29575",
+		"/usr/bin/hallo":                 "file 0775 eaf29575",
+		"/bin/":                          "dir 0755",
+		"/bin/hallo":                     "symlink ../usr/bin/hallo",
+		"/etc/":                          "dir 0755",
+		"/etc/dir/":                      "dir 0755",
+		"/etc/dir/sub/":                  "dir 01777",
+		"/etc/passwd":                    "file 0644 5b41362b",
+		"/var/":                          "dir 0755",
+		"/var/lib/":                      "dir 0755",
+		"/var/lib/chisel/":               "dir 0755",
+		"/var/lib/chisel/chisel.db":      "file 0755 194620de",
+	},
+}, {
+	summary: "Third Run, new slice requiring previous slice",
+	arch:    "amd64",
+	slices:  []setup.SliceKey{{"base-files", "theirslice"}},
+	release: testReleasesOfBaseFiles,
+	result: map[string]string{
+		"/tmp/":                          "dir 01777",
+		"/tmp/file1":                     "file 0644 5b41362b",
+		"/tmp/file3":                     "file 0644 5b41362b",
+		"/tmp/file4":                     "file 0644 d98cf53e",
+		"/usr/":                          "dir 0755",
+		"/usr/bin/":                      "dir 0755",
+		"/usr/bin/hello":                 "file 0775 eaf29575",
+		"/usr/bin/hello1":                "file 0775 eaf29575",
+		"/usr/bin/hello3":                "file 0775 eaf29575",
+		"/usr/bin/hallo":                 "file 0775 eaf29575",
+		"/bin/":                          "dir 0755",
+		"/bin/hallo":                     "symlink ../usr/bin/hallo",
+		"/etc/":                          "dir 0755",
+		"/etc/dir/":                      "dir 0755",
+		"/etc/dir/sub/":                  "dir 01777",
+		"/etc/passwd":                    "file 0644 5b41362b",
+		"/var/":                          "dir 0755",
+		"/var/lib/":                      "dir 0755",
+		"/var/lib/chisel/":               "dir 0755",
+		"/var/lib/chisel/chisel.db":      "file 0755 03c28243",
+	},
+}, {
+	summary: "Fourth Run, reinstall previous slice",
+	slices:  []setup.SliceKey{{"base-files", "myslice"}},
+	release: testReleasesOfBaseFiles,
+	result: map[string]string{
+		"/tmp/":                          "dir 01777",
+		"/tmp/file1":                     "file 0644 5b41362b",
+		"/tmp/file3":                     "file 0644 5b41362b",
+		"/tmp/file4":                     "file 0644 d98cf53e",
+		"/usr/":                          "dir 0755",
+		"/usr/bin/":                      "dir 0755",
+		"/usr/bin/hello":                 "file 0775 eaf29575",
+		"/usr/bin/hello1":                "file 0775 eaf29575",
+		"/usr/bin/hello3":                "file 0775 eaf29575",
+		"/usr/bin/hallo":                 "file 0775 eaf29575",
+		"/bin/":                          "dir 0755",
+		"/bin/hallo":                     "symlink ../usr/bin/hallo",
+		"/etc/":                          "dir 0755",
+		"/etc/dir/":                      "dir 0755",
+		"/etc/dir/sub/":                  "dir 01777",
+		"/etc/passwd":                    "file 0644 5b41362b",
+		"/var/":                          "dir 0755",
+		"/var/lib/":                      "dir 0755",
+		"/var/lib/chisel/":               "dir 0755",
+		"/var/lib/chisel/chisel.db":      "file 0755 03c28243",
+	},
+}}
+
+type testArchive struct {
+	arch string
+	pkgs map[string][]byte
+}
+
+func (a *testArchive) Options() *archive.Options {
+	return &archive.Options{Arch: a.arch}
+}
+
+func (a *testArchive) Fetch(pkg string) (io.ReadCloser, error) {
+	if data, ok := a.pkgs[pkg]; ok {
+		return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	}
+	return nil, fmt.Errorf("attempted to open %q package", pkg)
+}
+
+func (a *testArchive) Exists(pkg string) bool {
+	_, ok := a.pkgs[pkg]
+	return ok
+}
+
+func(test *testRun) installTestSlices(c *C, targetDir string, db *setup.ChiselDB) error {
+	releaseDir := c.MkDir()
+	for path, data := range test.release {
+		fpath := filepath.Join(releaseDir, path)
+		err := os.MkdirAll(filepath.Dir(fpath), 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(fpath, testutil.Reindent(data), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	release, err := setup.ReadRelease(releaseDir)
+	c.Assert(err, IsNil)
+
+	selection, err := setup.Select(release, test.slices, db)
+	c.Assert(err, IsNil)
+
+	archives := map[string]archive.Archive{
+		"ubuntu": &testArchive{
+			arch: test.arch,
+			pkgs: map[string][]byte{
+				"base-files": testutil.PackageData["base-files"],
+			},
+		},
+	}
+
+	options := slicer.RunOptions{
+		Selection: selection,
+		Archives:  archives,
+		TargetDir: targetDir,
+	}
+	err = slicer.Run(&options)
+	c.Assert(err, IsNil)
+
+	err = db.WriteInstalledSlices(targetDir, selection.Slices)
+	c.Assert(err, IsNil)
+
+	if test.result != nil {
+		c.Assert(testutil.TreeDump(targetDir), DeepEquals, test.result)
+	}
+
+	return nil
+}
+
+func(s *S) TestChiselDB(c *C) {
+	targetDir := c.MkDir()
+
+	for _, test := range testRuns {
+		c.Logf("Summary: %s", test.summary)
+
+		db, err := setup.ReadDB(targetDir)
+		c.Assert(err, IsNil)
+
+		err = test.installTestSlices(c, targetDir, db)
+		c.Assert(err, IsNil)
+
+		// check if installed slices are appended in "db"
+		for _, slice := range test.slices {
+			isInstalled := db.IsSliceInstalled(slice)
+			c.Assert(isInstalled, DeepEquals, true)
+		}
+
+		db, err = setup.ReadDB(targetDir)
+		c.Assert(err, IsNil)
+
+		// check if installed slices are present in the database file
+		for _, slice := range test.slices {
+			isInstalled := db.IsSliceInstalled(slice)
+			c.Assert(isInstalled, DeepEquals, true)
+		}
+	}
+}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -363,7 +363,7 @@ func (s *S) TestRun(c *C) {
 		release, err := setup.ReadRelease(releaseDir)
 		c.Assert(err, IsNil)
 
-		selection, err := setup.Select(release, test.slices)
+		selection, err := setup.Select(release, test.slices, &setup.ChiselDB{})
 		c.Assert(err, IsNil)
 
 		archives := map[string]archive.Archive{


### PR DESCRIPTION
Resolves #10 

Chisel records installed slices and checks before installing again
    - Records are saved at /var/lib/chisel/chisel.db
    - Slice names are kept in pkg_slice format one per line

Fix: Symlink overwrite
    * Info: In Go, os.Symlink fails if symlink already exists
    * Help: https://stackoverflow.com/questions/37345844/how-to-overwrite-a-symlink-in-go