### PR TITLE
Add PR template to remind contributors about the CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
+
+-----


### PR DESCRIPTION
Just adding a PR template so that all new PRs contain a statement alluding to the contributor's conformity to our CLA.