### PR TITLE
CI: Add CLA check, Linting and security scanning

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,12 @@
+name: CLA check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check if Canonical's Contributor License Agreement has been signed
+        uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,4 +27,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.1
-          args: --disable-all --enable errcheck,staticcheck,unused

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Ensure no formatting changes
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Check bugs and unused code
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54.1
+          args: --disable-all --enable errcheck,staticcheck,unused

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,20 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    name: Scan for known vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in fs mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,55 @@
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - staticcheck
+    - unused
+
+issues:
+  exclude-rules:
+    # exclusions for errcheck
+    - path: "^.*/log.go$"
+      text: "globalLogger.Output.*not checked"
+      linters:
+        - errcheck
+    - path: "^.*_test.go$"
+      text: "release.Render.*not checked"
+      linters:
+        - errcheck
+    - path: "^.*_test.go$"
+      text: "release.Walk.*not checked"
+      linters:
+        - errcheck
+    - path: "internal/setup/fetch.go"
+      text: "lockFile.Unlock.*not checked"
+      linters:
+        - errcheck
+    # exclusions for unused
+    # addDebugCommand is an useful function that may be used later
+    - path: "cmd/chisel/main.go"
+      text: "addDebugCommand.*unused"
+      linters:
+        - unused
+    # exclude common (unused) issues from log.go files
+    - path: "^.*/log.go$"
+      text: "logf.*unused"
+      linters:
+        - unused
+    - path: "^.*/log.go$"
+      text: "debugf.*unused"
+      linters:
+        - unused
+    - path: "^.*/log.go$"
+      text: "globalDebug.*unused"
+      linters:
+        - unused
+    - path: "^.*/log.go$"
+      text: "globalLogger.*unused"
+      linters:
+        - unused
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -103,8 +103,6 @@ func (cmd *cmdCut) Execute(args []string) error {
 		Archives:  archives,
 		TargetDir: cmd.RootDir,
 	})
-
-	return printVersions()
 }
 
 // TODO These need testing, and maybe moving into a common file.

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -120,7 +120,7 @@ func parseReleaseInfo(release string) (label, version string, err error) {
 }
 
 func readReleaseInfo() (label, version string, err error) {
-	data, err := ioutil.ReadFile("/etc/lsb-release")
+	data, err := os.ReadFile("/etc/lsb-release")
 	if err == nil {
 		const labelPrefix = "DISTRIB_ID="
 		const versionPrefix = "DISTRIB_RELEASE="

--- a/cmd/chisel/cmd_help.go
+++ b/cmd/chisel/cmd_help.go
@@ -100,9 +100,10 @@ func (w *manfixer) Write(buf []byte) (int, error) {
 
 var tpRegexp = regexp.MustCompile(`(?m)(?:^\.TP\n)+`)
 
-func (w *manfixer) flush() {
+func (w *manfixer) flush() error {
 	str := tpRegexp.ReplaceAllLiteralString(w.Buffer.String(), ".TP\n")
-	io.Copy(Stdout, strings.NewReader(str))
+	_, err := io.Copy(Stdout, strings.NewReader(str))
+	return err
 }
 
 func (cmd cmdHelp) Execute(args []string) error {
@@ -114,8 +115,8 @@ func (cmd cmdHelp) Execute(args []string) error {
 		// subcommand, but --man is hidden so no real need to check.
 		out := &manfixer{}
 		cmd.parser.WriteManPage(out)
-		out.flush()
-		return nil
+		err := out.flush()
+		return err
 	}
 	if cmd.All {
 		if len(cmd.Positional.Subs) > 0 {

--- a/cmd/chisel/cmd_version.go
+++ b/cmd/chisel/cmd_version.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -14,7 +13,7 @@ var longVersionHelp = `
 The version command displays the versions of the running client and server.
 `
 
-type cmdVersion struct {}
+type cmdVersion struct{}
 
 func init() {
 	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, nil, nil)

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -10,8 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/jessevdk/go-flags"
-
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/canonical/chisel/internal/archive"
 	"github.com/canonical/chisel/internal/deb"
@@ -26,7 +25,7 @@ var (
 	Stdout io.Writer = os.Stdout
 	Stderr io.Writer = os.Stderr
 	// overridden for testing
-	ReadPassword = terminal.ReadPassword
+	ReadPassword = term.ReadPassword
 	// set to logger.Panicf in testing
 	//noticef = logger.Noticef
 )
@@ -285,8 +284,8 @@ func Parser() *flags.Parser {
 }
 
 var (
-	isStdinTTY  = terminal.IsTerminal(0)
-	isStdoutTTY = terminal.IsTerminal(1)
+	isStdinTTY  = term.IsTerminal(0)
+	isStdoutTTY = term.IsTerminal(1)
 )
 
 func main() {

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -18,9 +17,7 @@ import (
 	"github.com/canonical/chisel/internal/deb"
 	"github.com/canonical/chisel/internal/setup"
 	"github.com/canonical/chisel/internal/slicer"
-
 	//"github.com/canonical/chisel/internal/logger"
-
 )
 
 var (

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -155,7 +155,10 @@ func fixupArg(optName string) string {
 // from each other.
 func Parser() *flags.Parser {
 	optionsData.Version = func() {
-		printVersions()
+		err := printVersions()
+		if err != nil {
+			panic(&exitStatus{1})
+		}
 		panic(&exitStatus{0})
 	}
 	flagopts := flags.Options(flags.PassDoubleDash)
@@ -169,7 +172,10 @@ func Parser() *flags.Parser {
 		version.Hidden = true
 	}
 	// add --help like what go-flags would do for us, but hidden
-	addHelp(parser)
+	err := addHelp(parser)
+	if err != nil {
+		debugf("cannot add --help: %v", err)
+	}
 
 	// Add all regular commands
 	for _, c := range commands {

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -31,11 +31,6 @@ var (
 	//noticef = logger.Noticef
 )
 
-// defaultChiselDir is the Chisel directory used if $CHISEL is not set. It is
-// created by the daemon ("chisel run") if it doesn't exist, and also used by
-// the chisel client.
-const defaultChiselDir = "/var/lib/chisel/default"
-
 type options struct {
 	Version func() `long:"version"`
 }

--- a/cmd/chisel/main_test.go
+++ b/cmd/chisel/main_test.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/crypto/ssh/terminal"
-
+	"golang.org/x/term"
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/chisel/cmd"
@@ -51,7 +50,7 @@ func (s *BaseChiselSuite) TearDownTest(c *C) {
 	chisel.Stdin = os.Stdin
 	chisel.Stdout = os.Stdout
 	chisel.Stderr = os.Stderr
-	chisel.ReadPassword = terminal.ReadPassword
+	chisel.ReadPassword = term.ReadPassword
 
 	s.BaseTest.TearDownTest(c)
 }

--- a/cmd/chisel/main_test.go
+++ b/cmd/chisel/main_test.go
@@ -70,12 +70,6 @@ func (s *BaseChiselSuite) ResetStdStreams() {
 	s.stderr.Reset()
 }
 
-func fakeArgs(args ...string) (restore func()) {
-	old := os.Args
-	os.Args = args
-	return func() { os.Args = old }
-}
-
 func fakeVersion(v string) (restore func()) {
 	old := cmd.Version
 	cmd.Version = v

--- a/cmd/chisel/main_test.go
+++ b/cmd/chisel/main_test.go
@@ -20,10 +20,10 @@ func Test(t *testing.T) { TestingT(t) }
 
 type BaseChiselSuite struct {
 	testutil.BaseTest
-	stdin     *bytes.Buffer
-	stdout    *bytes.Buffer
-	stderr    *bytes.Buffer
-	password  string
+	stdin    *bytes.Buffer
+	stdout   *bytes.Buffer
+	stderr   *bytes.Buffer
+	password string
 }
 
 func (s *BaseChiselSuite) readPassword(fd int) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/klauspost/compress v1.15.4
 	github.com/ulikunitz/xz v0.5.10
 	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd
-	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
+	golang.org/x/term v0.12.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99
 )
@@ -17,6 +17,5 @@ require (
 require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.1.0 // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd h1:Uo/x0Ir5vQJ+683GXB9Ug+4fcjsbp7z7Ul8UaZbhsRM=
 go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898 h1:SLP7Q4Di66FONjDJbCYrCRrh97focO6sLogHO7/g8F0=
-golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -59,12 +57,11 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.12.0 h1:/ZfYdc3zq+q02Rv9vGqTeSItdzZTSNDmfTi0mBAuidU=
+golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -142,10 +142,10 @@ var optionErrorTests = []optionErrorTest{{
 	error: `archive has no component "other"`,
 }, {
 	options: archive.Options{
-		Label:    "ubuntu",
-		Version:  "22.04",
-		Arch:     "amd64",
-		Suites:     []string{"jammy"},
+		Label:   "ubuntu",
+		Version: "22.04",
+		Arch:    "amd64",
+		Suites:  []string{"jammy"},
 	},
 	error: "archive options missing components",
 }, {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -8,9 +8,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -65,7 +65,7 @@ func (s *httpSuite) Do(req *http.Request) (*http.Response, error) {
 		body = string(response)
 	}
 	rsp := &http.Response{
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     s.header,
 		StatusCode: s.status,
 	}
@@ -333,7 +333,7 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 }
 
 func read(r io.Reader) string {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}
@@ -405,7 +405,7 @@ func (s *S) testOpenArchiveArch(c *C, arch string) {
 	})
 	c.Assert(err, IsNil)
 
-	data, err := ioutil.ReadFile(filepath.Join(extractDir, "copyright"))
+	data, err := os.ReadFile(filepath.Join(extractDir, "copyright"))
 	c.Assert(err, IsNil)
 
 	copyrightTop := "This package was written by Peter Tobias <tobias@et-inf.fho-emden.de>\non Thu, 16 Jan 1997 01:00:34 +0100."

--- a/internal/archive/credentials_test.go
+++ b/internal/archive/credentials_test.go
@@ -1,7 +1,6 @@
 package archive_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -231,7 +230,7 @@ func (s *S) runFindCredentialsInDirTest(c *C, t *credentialsTest) {
 		fpath := filepath.Join(credsDir, filename)
 		err := os.MkdirAll(filepath.Dir(fpath), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(fpath, []byte(data), 0644)
+		err = os.WriteFile(fpath, []byte(data), 0644)
 		c.Assert(err, IsNil)
 	}
 

--- a/internal/archive/export_test.go
+++ b/internal/archive/export_test.go
@@ -16,5 +16,6 @@ func FakeDo(do func(req *http.Request) (*http.Response, error)) (restore func())
 }
 
 type Credentials = credentials
+
 var FindCredentials = findCredentials
 var FindCredentialsInDir = findCredentialsInDir

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -42,7 +42,6 @@ func (s *S) TestDefaultDir(c *C) {
 	c.Assert(strings.HasSuffix(defaultDir, "/foo/bar"), Equals, true)
 }
 
-
 func (s *S) TestCacheEmpty(c *C) {
 	cc := cache.Cache{c.MkDir()}
 
@@ -129,7 +128,7 @@ func (s *S) TestCacheWrongDigest(c *C) {
 	_, err := w.Write([]byte("data2"))
 	errClose := w.Close()
 	c.Assert(err, IsNil)
-	c.Assert(errClose, ErrorMatches, "expected digest " + data1Digest + ", got " + data2Digest)
+	c.Assert(errClose, ErrorMatches, "expected digest "+data1Digest+", got "+data2Digest)
 
 	_, err = cc.Read(data1Digest)
 	c.Assert(err, Equals, cache.MissErr)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -3,7 +3,7 @@ package cache_test
 import (
 	. "gopkg.in/check.v1"
 
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,7 +144,7 @@ func (s *S) TestCacheOpen(c *C) {
 
 	f, err := cc.Open(data1Digest)
 	c.Assert(err, IsNil)
-	data1, err := ioutil.ReadAll(f)
+	data1, err := io.ReadAll(f)
 	closeErr := f.Close()
 	c.Assert(err, IsNil)
 	c.Assert(closeErr, IsNil)

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 )
 
-
 // The logic in this file is supposed to be fast so that parsing large data
 // files feels instantaneous. It does that by performing a fast scan once to
 // index the sections, and then rather than parsing the individual sections it

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -3,7 +3,6 @@ package control
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -102,7 +101,7 @@ type ctrlPos struct {
 }
 
 func ParseReader(sectionKey string, content io.Reader) (File, error) {
-	data, err := ioutil.ReadAll(content)
+	data, err := io.ReadAll(content)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -88,7 +88,10 @@ func BenchmarkParse(b *testing.B) {
 	content := string(data)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		control.ParseString("Package", content)
+		_, err := control.ParseString("Package", content)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/canonical/chisel/internal/control"
 
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -29,7 +29,7 @@ Line: line for three
 Section: three
 
 Section: four
-Multi: 
+Multi:
  Space at EOL above
   Extra space
 	One tab
@@ -81,7 +81,7 @@ func (s *S) TestParseReader(c *C) {
 }
 
 func BenchmarkParse(b *testing.B) {
-	data, err := ioutil.ReadFile("Packages")
+	data, err := os.ReadFile("Packages")
 	if err != nil {
 		b.Fatalf("cannot open Packages file: %v", err)
 	}
@@ -93,7 +93,7 @@ func BenchmarkParse(b *testing.B) {
 }
 
 func BenchmarkSectionGet(b *testing.B) {
-	data, err := ioutil.ReadFile("Packages")
+	data, err := os.ReadFile("Packages")
 	if err != nil {
 		b.Fatalf("cannot open Packages file: %v", err)
 	}

--- a/internal/control/helpers.go
+++ b/internal/control/helpers.go
@@ -11,7 +11,7 @@ var pathInfoExp = regexp.MustCompile(`([a-f0-9]{32,}) +([0-9]+) +\S+`)
 func ParsePathInfo(table, path string) (digest string, size int, ok bool) {
 	pos := strings.Index(table, " "+path+"\n")
 	if pos == -1 {
-		if !strings.HasSuffix(table, " " + path) {
+		if !strings.HasSuffix(table, " "+path) {
 			return "", -1, false
 		}
 		pos = len(table) - len(path)

--- a/internal/control/helpers_test.go
+++ b/internal/control/helpers_test.go
@@ -39,21 +39,21 @@ var parsePathInfoTests = []parsePathInfoTest{{
 	size:   2,
 	digest: "0123456789abcdef0123456789abcdef",
 }, {
-	table: `0123456789abcdef0123456789abcdef 0 /the/path`,
+	table:  `0123456789abcdef0123456789abcdef 0 /the/path`,
 	path:   "/the/path",
 	size:   0,
 	digest: "0123456789abcdef0123456789abcdef",
 }, {
-	table: `0123456789abcdef0123456789abcdef    555    /the/path`,
+	table:  `0123456789abcdef0123456789abcdef    555    /the/path`,
 	path:   "/the/path",
 	size:   555,
 	digest: "0123456789abcdef0123456789abcdef",
 }, {
-	table: `deadbeef 0 /the/path`,
+	table:  `deadbeef 0 /the/path`,
 	path:   "/the/path",
 	digest: "",
 }, {
-	table: `bad-data 0 /the/path`,
+	table:  `bad-data 0 /the/path`,
 	path:   "/the/path",
 	digest: "",
 }}

--- a/internal/control/suite_test.go
+++ b/internal/control/suite_test.go
@@ -11,4 +11,3 @@ func Test(t *testing.T) { TestingT(t) }
 type S struct{}
 
 var _ = Suite(&S{})
-

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -206,7 +205,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			// memory at once this logic might open the first file
 			// written and copy it every time. For now, the choice
 			// is speed over memory efficiency.
-			data, err := ioutil.ReadAll(tarReader)
+			data, err := io.ReadAll(tarReader)
 			if err != nil {
 				return err
 			}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -149,10 +149,10 @@ var extractTests = []extractTest{{
 		},
 	},
 	result: map[string]string{
-		"/etc/":                    "dir 0755",
-		"/etc/dpkg/":               "dir 0755",
-		"/etc/default/":            "dir 0755",
-		"/etc/debian_version":      "file 0644 cce26cfe",
+		"/etc/":               "dir 0755",
+		"/etc/dpkg/":          "dir 0755",
+		"/etc/default/":       "dir 0755",
+		"/etc/debian_version": "file 0644 cce26cfe",
 	},
 	globbed: map[string][]string{
 		"/etc/dp*/": []string{"/etc/dpkg/"},

--- a/internal/deb/version.go
+++ b/internal/deb/version.go
@@ -150,9 +150,10 @@ func compareSubversion(va, vb string) int {
 // CompareVersions compare two version strings that follow the debian
 // version policy and
 // Returns:
-//   -1 if a is smaller than b
-//    0 if a equals b
-//   +1 if a is bigger than b
+//
+//	-1 if a is smaller than b
+//	 0 if a equals b
+//	+1 if a is bigger than b
 func CompareVersions(va, vb string) int {
 	var sa, sb string
 	if ia := strings.IndexByte(va, '-'); ia < 0 {

--- a/internal/deb/version.go
+++ b/internal/deb/version.go
@@ -83,32 +83,6 @@ func cmpNumeric(a, b string) int {
 	return 0
 }
 
-func matchEpoch(a string) bool {
-	if len(a) == 0 {
-		return false
-	}
-	if a[0] < '0' || a[0] > '9' {
-		return false
-	}
-	var i int
-	for i = 1; i < len(a) && a[i] >= '0' && a[i] <= '9'; i++ {
-	}
-	return i < len(a) && a[i] == ':'
-}
-
-func atMostOneDash(a string) bool {
-	seen := false
-	for i := 0; i < len(a); i++ {
-		if a[i] == '-' {
-			if seen {
-				return false
-			}
-			seen = true
-		}
-	}
-	return true
-}
-
 func nextFrag(s string) (frag, rest string, numeric bool) {
 	if len(s) == 0 {
 		return "", "", false

--- a/internal/deb/version_test.go
+++ b/internal/deb/version_test.go
@@ -71,28 +71,28 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		{"1.0", "1.0-0+b1", -1},
 		{"1.0", "1.0-0~", 1},
 		// from the old perl cupt
-		{"1.2.3", "1.2.3", 0},                   // identical
-		{"4.4.3-2", "4.4.3-2", 0},               // identical
-		{"1.2.3", "1.2.3-0", 0},                 // zero revision
-		{"009", "9", 0},                         // zeroes…
-		{"009ab5", "9ab5", 0},                   // there as well
-		{"1.2.3", "1.2.3-1", -1},                // added non-zero revision
-		{"1.2.3", "1.2.4", -1},                  // just bigger
-		{"1.2.4", "1.2.3", 1},                   // order doesn't matter
-		{"1.2.24", "1.2.3", 1},                  // bigger, eh?
-		{"0.10.0", "0.8.7", 1},                  // bigger, eh?
-		{"3.2", "2.3", 1},                       // major number rocks
-		{"1.3.2a", "1.3.2", 1},                  // letters rock
-		{"0.5.0~git", "0.5.0~git2", -1},         // numbers rock
-		{"2a", "21", -1},                        // but not in all places
-		{"1.2a+~bCd3", "1.2a++", -1},            // tilde doesn't rock
-		{"1.2a+~bCd3", "1.2a+~", 1},             // but first is longer!
-		{"5.10.0", "5.005", 1},                  // preceding zeroes don't matters
-		{"3a9.8", "3.10.2", -1},                 // letters are before all letter symbols
-		{"3a9.8", "3~10", 1},                    // but after the tilde
-		{"1.4+OOo3.0.0~", "1.4+OOo3.0.0-4", -1}, // another tilde check
-		{"2.4.7-1", "2.4.7-z", -1},              // revision comparing
-		{"1.002-1+b2", "1.00", 1},               // whatever...
+		{"1.2.3", "1.2.3", 0},                                // identical
+		{"4.4.3-2", "4.4.3-2", 0},                            // identical
+		{"1.2.3", "1.2.3-0", 0},                              // zero revision
+		{"009", "9", 0},                                      // zeroes…
+		{"009ab5", "9ab5", 0},                                // there as well
+		{"1.2.3", "1.2.3-1", -1},                             // added non-zero revision
+		{"1.2.3", "1.2.4", -1},                               // just bigger
+		{"1.2.4", "1.2.3", 1},                                // order doesn't matter
+		{"1.2.24", "1.2.3", 1},                               // bigger, eh?
+		{"0.10.0", "0.8.7", 1},                               // bigger, eh?
+		{"3.2", "2.3", 1},                                    // major number rocks
+		{"1.3.2a", "1.3.2", 1},                               // letters rock
+		{"0.5.0~git", "0.5.0~git2", -1},                      // numbers rock
+		{"2a", "21", -1},                                     // but not in all places
+		{"1.2a+~bCd3", "1.2a++", -1},                         // tilde doesn't rock
+		{"1.2a+~bCd3", "1.2a+~", 1},                          // but first is longer!
+		{"5.10.0", "5.005", 1},                               // preceding zeroes don't matters
+		{"3a9.8", "3.10.2", -1},                              // letters are before all letter symbols
+		{"3a9.8", "3~10", 1},                                 // but after the tilde
+		{"1.4+OOo3.0.0~", "1.4+OOo3.0.0-4", -1},              // another tilde check
+		{"2.4.7-1", "2.4.7-z", -1},                           // revision comparing
+		{"1.002-1+b2", "1.00", 1},                            // whatever...
 		{"12-20220319-1ubuntu1", "12-20220319-1ubuntu2", -1}, // libgcc-s1
 		{"1:13.0.1-2ubuntu2", "1:13.0.1-2ubuntu3", -1},
 	} {

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -56,7 +56,7 @@ var createTests = []createTest{{
 		Mode: fs.ModeDir | fs.ModeSticky | 0775,
 	},
 	result: map[string]string{
-		"/tmp/":     "dir 01775",
+		"/tmp/": "dir 01775",
 	},
 }, {
 	options: fsutil.CreateOptions{

--- a/internal/jsonwall/jsonwall.go
+++ b/internal/jsonwall/jsonwall.go
@@ -45,7 +45,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 )
@@ -136,7 +135,7 @@ func (dbw *DBWriter) WriteTo(w io.Writer) (n int64, err error) {
 
 // ReadDB reads into memory the database from the provided r.
 func ReadDB(r io.Reader) (*DB, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jsonwall/jsonwall.go
+++ b/internal/jsonwall/jsonwall.go
@@ -1,4 +1,3 @@
-//
 // Package jsonwall provides an interface to work with database files in the simple
 // "jsonwall" format, which consists of a text file with one JSON object per line,
 // where both the individual JSON fields and the lines themselves are sorted to
@@ -6,17 +5,17 @@
 //
 // For example, the following content represents a valid jsonwall database:
 //
-//     {"jsonwall":"1.0","count":3}
-//     {"kind":"app","name":"chisel","version":"1.0"}
-//     {"kind":"app","name":"pebble","version":"1.2"}
+//	{"jsonwall":"1.0","count":3}
+//	{"kind":"app","name":"chisel","version":"1.0"}
+//	{"kind":"app","name":"pebble","version":"1.2"}
 //
 // The entries in this database might be manipulated with a type such as:
 //
-//     type AppEntry struct {
-//             Kind string    `json:"kind"`
-//             Name string    `json:"name,omitempty"`
-//             Version string `json:"version,omitempty"`
-//     }
+//	type AppEntry struct {
+//	        Kind string    `json:"kind"`
+//	        Name string    `json:"name,omitempty"`
+//	        Version string `json:"version,omitempty"`
+//	}
 //
 // Such data types have two important characteristics: fields must be defined in
 // the order that will be used when searching, and every optional field must be
@@ -24,22 +23,21 @@
 //
 // With that in place, the database may be accessed as:
 //
-//     app := AppEntry{Kind: "app", Name: "chisel"}
-//     if db.Get(&app) == nil {
-//             fmt.Println(app.Name, "version:", app.Version)
-//     }
+//	app := AppEntry{Kind: "app", Name: "chisel"}
+//	if db.Get(&app) == nil {
+//	        fmt.Println(app.Name, "version:", app.Version)
+//	}
 //
 // Iteration works similarly:
 //
-//     app := AppEntry{Kind: "app"}
-//     if iter, err := db.Iter(&app); err == nil {
-//             for iter.Next() {
-//                     if iter.Get(&app) == nil {
-//                             fmt.Println(app.Name, "version:", app.Version)
-//                     }
-//             }
-//     }
-//
+//	app := AppEntry{Kind: "app"}
+//	if iter, err := db.Iter(&app); err == nil {
+//	        for iter.Next() {
+//	                if iter.Get(&app) == nil {
+//	                        fmt.Println(app.Name, "version:", app.Version)
+//	                }
+//	        }
+//	}
 package jsonwall
 
 import (

--- a/internal/jsonwall/jsonwall_test.go
+++ b/internal/jsonwall/jsonwall_test.go
@@ -150,7 +150,7 @@ var dataTypeTests = []struct {
 	}},
 }, {
 	summary: "Invalid add request",
-	values:  []any{
+	values: []any{
 		42,
 	},
 	dbError: "invalid database value: 42",

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -5,7 +5,6 @@ import (
 	"go.starlark.net/starlark"
 
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,7 +148,7 @@ func (c *ContentValue) Read(thread *starlark.Thread, fn *starlark.Builtin, args 
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(fpath)
+	data, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, c.polishError(path, err)
 	}
@@ -172,7 +171,7 @@ func (c *ContentValue) Write(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	// No mode parameter for now as slices are supposed to list files
 	// explicitly instead.
-	err = ioutil.WriteFile(fpath, fdata, 0644)
+	err = os.WriteFile(fpath, fdata, 0644)
 	if err != nil {
 		return nil, c.polishError(path, err)
 	}
@@ -194,7 +193,7 @@ func (c *ContentValue) List(thread *starlark.Thread, fn *starlark.Builtin, args 
 	if err != nil {
 		return nil, err
 	}
-	entries, err := ioutil.ReadDir(fpath)
+	entries, err := os.ReadDir(fpath)
 	if err != nil {
 		return nil, c.polishError(path, err)
 	}

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -2,7 +2,6 @@ package scripts_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -211,7 +210,7 @@ func (s *S) TestScripts(c *C) {
 			fpath := filepath.Join(rootDir, path)
 			err := os.MkdirAll(filepath.Dir(fpath), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fpath, []byte(data), 0644)
+			err = os.WriteFile(fpath, []byte(data), 0644)
 			c.Assert(err, IsNil)
 		}
 		if test.hackdir != nil {

--- a/internal/setup/fetch.go
+++ b/internal/setup/fetch.go
@@ -38,7 +38,7 @@ func FetchRelease(options *FetchOptions) (*Release, error) {
 		cacheDir = cache.DefaultDir("chisel")
 	}
 
-	dirName := filepath.Join(cacheDir, "releases", options.Label + "-" + options.Version)
+	dirName := filepath.Join(cacheDir, "releases", options.Label+"-"+options.Version)
 	err := os.MkdirAll(dirName, 0755)
 	if err == nil {
 		lockFile := fslock.New(filepath.Join(cacheDir, "releases", ".lock"))
@@ -57,7 +57,7 @@ func FetchRelease(options *FetchOptions) (*Release, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", baseURL + options.Label + "-" + options.Version, nil)
+	req, err := http.NewRequest("GET", baseURL+options.Label+"-"+options.Version, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request for release information: %w", err)
 	}

--- a/internal/setup/fetch.go
+++ b/internal/setup/fetch.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,7 +51,7 @@ func FetchRelease(options *FetchOptions) (*Release, error) {
 	}
 
 	tagName := filepath.Join(dirName, ".etag")
-	tagData, err := ioutil.ReadFile(tagName)
+	tagData, err := os.ReadFile(tagName)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -99,7 +98,7 @@ func FetchRelease(options *FetchOptions) (*Release, error) {
 		}
 		tag := resp.Header.Get("ETag")
 		if tag != "" {
-			err := ioutil.WriteFile(tagName, []byte(tag), 0644)
+			err := os.WriteFile(tagName, []byte(tag), 0644)
 			if err != nil {
 				return nil, fmt.Errorf("cannot write remote release tag file: %v", err)
 			}

--- a/internal/setup/fetch_test.go
+++ b/internal/setup/fetch_test.go
@@ -3,7 +3,6 @@ package setup_test
 import (
 	. "gopkg.in/check.v1"
 
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -35,16 +34,16 @@ func (s *S) TestFetch(c *C) {
 		markerPath := filepath.Join(release.Path, "test.marker")
 		switch fetch {
 		case 0:
-			err := ioutil.WriteFile(markerPath, nil, 0644)
+			err := os.WriteFile(markerPath, nil, 0644)
 			c.Assert(err, IsNil)
 		case 1:
-			_, err := ioutil.ReadFile(markerPath)
+			_, err := os.ReadFile(markerPath)
 			c.Assert(err, IsNil)
 
-			err = ioutil.WriteFile(filepath.Join(release.Path, ".etag"), []byte("wrong"), 0644)
+			err = os.WriteFile(filepath.Join(release.Path, ".etag"), []byte("wrong"), 0644)
 			c.Assert(err, IsNil)
 		case 2:
-			_, err := ioutil.ReadFile(markerPath)
+			_, err := os.ReadFile(markerPath)
 			c.Assert(os.IsNotExist(err), Equals, true)
 		}
 	}

--- a/internal/setup/fetch_test.go
+++ b/internal/setup/fetch_test.go
@@ -14,8 +14,8 @@ import (
 
 func (s *S) TestFetch(c *C) {
 	options := &setup.FetchOptions{
-		Label: "ubuntu",
-		Version: "22.04",
+		Label:    "ubuntu",
+		Version:  "22.04",
 		CacheDir: c.MkDir(),
 	}
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,7 +1,6 @@
 package setup_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -815,7 +814,7 @@ func (s *S) TestParseRelease(c *C) {
 			fpath := filepath.Join(dir, path)
 			err := os.MkdirAll(filepath.Dir(fpath), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fpath, testutil.Reindent(data), 0644)
+			err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
 			c.Assert(err, IsNil)
 		}
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -14,7 +14,6 @@ import (
 type setupTest struct {
 	summary   string
 	input     map[string]string
-	slices    map[string]*setup.Slice
 	release   *setup.Release
 	relerror  string
 	selslices []setup.SliceKey

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -537,7 +536,7 @@ func (a *testArchive) Options() *archive.Options {
 
 func (a *testArchive) Fetch(pkg string) (io.ReadCloser, error) {
 	if data, ok := a.pkgs[pkg]; ok {
-		return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+		return io.NopCloser(bytes.NewBuffer(data)), nil
 	}
 	return nil, fmt.Errorf("attempted to open %q package", pkg)
 }
@@ -560,7 +559,7 @@ func (s *S) TestRun(c *C) {
 			fpath := filepath.Join(releaseDir, path)
 			err := os.MkdirAll(filepath.Dir(fpath), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fpath, testutil.Reindent(data), 0644)
+			err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
 			c.Assert(err, IsNil)
 		}
 

--- a/internal/strdist/export_test.go
+++ b/internal/strdist/export_test.go
@@ -1,4 +1,3 @@
 package strdist
 
-
 var GlobCost = globCost

--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -20,8 +20,6 @@ type Cost struct {
 	SwapAB  CostInt
 	DeleteA CostInt
 	InsertB CostInt
-
-	private struct{}
 }
 
 type CostFunc func(ar, br rune) Cost

--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -103,10 +103,9 @@ func Distance(a, b string, f CostFunc, cut int64) int64 {
 //
 // Supported wildcards:
 //
-//     ?  - Any one character, except for /
-//     *  - Any zero or more characters, execept for /
-//     ** - Any zero or more characrers, including /
-//
+//	?  - Any one character, except for /
+//	*  - Any zero or more characters, execept for /
+//	** - Any zero or more characrers, including /
 func GlobPath(a, b string) bool {
 	a = strings.ReplaceAll(a, "**", "⁑")
 	b = strings.ReplaceAll(b, "**", "⁑")
@@ -128,4 +127,3 @@ func globCost(ar, br rune) Cost {
 	}
 	return Cost{SwapAB: 1, DeleteA: 1, InsertB: 1}
 }
-

--- a/internal/testutil/exec.go
+++ b/internal/testutil/exec.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -122,7 +121,7 @@ func FakeCommand(c *check.C, basename, script string) *FakeCmd {
 		os.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	}
 	fmt.Fprintf(&wholeScript, scriptTpl, logFile, script)
-	err := ioutil.WriteFile(exeFile, wholeScript.Bytes(), 0700)
+	err := os.WriteFile(exeFile, wholeScript.Bytes(), 0700)
 	if err != nil {
 		panic(err)
 	}
@@ -136,7 +135,7 @@ func FakeCommand(c *check.C, basename, script string) *FakeCmd {
 // Useful when you want to check the ordering of things.
 func (cmd *FakeCmd) Also(basename, script string) *FakeCmd {
 	exeFile := path.Join(cmd.binDir, basename)
-	err := ioutil.WriteFile(exeFile, []byte(fmt.Sprintf(scriptTpl, cmd.logFile, script)), 0700)
+	err := os.WriteFile(exeFile, []byte(fmt.Sprintf(scriptTpl, cmd.logFile, script)), 0700)
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +162,7 @@ func (cmd *FakeCmd) Restore() {
 //	    {"cmd", "arg1", "arg2"}, // second invocation of "cmd"
 //	}
 func (cmd *FakeCmd) Calls() [][]string {
-	raw, err := ioutil.ReadFile(cmd.logFile)
+	raw, err := os.ReadFile(cmd.logFile)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/internal/testutil/exec.go
+++ b/internal/testutil/exec.go
@@ -157,10 +157,11 @@ func (cmd *FakeCmd) Restore() {
 
 // Calls returns a list of calls that were made to the fake command.
 // of the form:
-// [][]string{
-//     {"cmd", "arg1", "arg2"}, // first invocation of "cmd"
-//     {"cmd", "arg1", "arg2"}, // second invocation of "cmd"
-// }
+//
+//	[][]string{
+//	    {"cmd", "arg1", "arg2"}, // first invocation of "cmd"
+//	    {"cmd", "arg1", "arg2"}, // second invocation of "cmd"
+//	}
 func (cmd *FakeCmd) Calls() [][]string {
 	raw, err := ioutil.ReadFile(cmd.logFile)
 	if os.IsNotExist(err) {

--- a/internal/testutil/exec_test.go
+++ b/internal/testutil/exec_test.go
@@ -16,7 +16,7 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -80,11 +80,11 @@ func (s *fakeCommandSuite) TestFakeShellchecksWhenAvailable(c *check.C) {
 		{"shellcheck", "-s", "bash", "-"},
 	})
 
-	scriptData, err := ioutil.ReadFile(fake.Exe())
+	scriptData, err := os.ReadFile(fake.Exe())
 	c.Assert(err, check.IsNil)
 	c.Assert(string(scriptData), Contains, "\necho some-command\n")
 
-	data, err := ioutil.ReadFile(filepath.Join(tmpDir, "input"))
+	data, err := os.ReadFile(filepath.Join(tmpDir, "input"))
 	c.Assert(err, check.IsNil)
 	c.Assert(data, check.DeepEquals, scriptData)
 }

--- a/internal/testutil/filecontentchecker.go
+++ b/internal/testutil/filecontentchecker.go
@@ -17,7 +17,7 @@ package testutil
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -68,7 +68,7 @@ func (c *fileContentChecker) Check(params []interface{}, names []string) (result
 }
 
 func fileContentCheck(filename string, content interface{}, exact bool) (result bool, error string) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read file %q: %v", filename, err)
 	}

--- a/internal/testutil/filecontentchecker_test.go
+++ b/internal/testutil/filecontentchecker_test.go
@@ -15,7 +15,7 @@
 package testutil_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -36,7 +36,7 @@ func (s *fileContentCheckerSuite) TestFileEquals(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 
 	testInfo(c, FileEquals, "FileEquals", []string{"filename", "contents"})
 	testCheck(c, FileEquals, true, "", filename, content)
@@ -57,7 +57,7 @@ func (s *fileContentCheckerSuite) TestFileContains(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 
 	testInfo(c, FileContains, "FileContains", []string{"filename", "contents"})
 	testCheck(c, FileContains, true, "", filename, content[1:])
@@ -82,7 +82,7 @@ func (s *fileContentCheckerSuite) TestFileMatches(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 
 	testInfo(c, FileMatches, "FileMatches", []string{"filename", "regex"})
 	testCheck(c, FileMatches, true, "", filename, ".*")

--- a/internal/testutil/filepresencechecker_test.go
+++ b/internal/testutil/filepresencechecker_test.go
@@ -16,7 +16,7 @@ package testutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
@@ -34,7 +34,7 @@ func (*filePresenceCheckerSuite) TestFilePresent(c *check.C) {
 	testInfo(c, FilePresent, "FilePresent", []string{"filename"})
 	testCheck(c, FilePresent, false, `filename must be a string`, 42)
 	testCheck(c, FilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
-	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FilePresent, true, "", filename)
 }
 
@@ -44,6 +44,6 @@ func (*filePresenceCheckerSuite) TestFileAbsent(c *check.C) {
 	testInfo(c, FileAbsent, "FileAbsent", []string{"filename"})
 	testCheck(c, FileAbsent, false, `filename must be a string`, 42)
 	testCheck(c, FileAbsent, true, "", filename)
-	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FileAbsent, false, fmt.Sprintf(`file %q is present but should not exist`, filename), filename)
 }

--- a/internal/testutil/intcheckers.go
+++ b/internal/testutil/intcheckers.go
@@ -59,35 +59,41 @@ func (checker *intChecker) Check(params []interface{}, names []string) (result b
 // IntLessThan checker verifies that one integer is less than other integer.
 //
 // For example:
-//     c.Assert(1, IntLessThan, 2)
+//
+//	c.Assert(1, IntLessThan, 2)
 var IntLessThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessThan", Params: []string{"a", "b"}}, rel: "<"}
 
 // IntLessEqual checker verifies that one integer is less than or equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntLessEqual, 1)
+//
+//	c.Assert(1, IntLessEqual, 1)
 var IntLessEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessEqual", Params: []string{"a", "b"}}, rel: "<="}
 
 // IntEqual checker verifies that one integer is equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntEqual, 1)
+//
+//	c.Assert(1, IntEqual, 1)
 var IntEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntEqual", Params: []string{"a", "b"}}, rel: "=="}
 
 // IntNotEqual checker verifies that one integer is not equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntNotEqual, 2)
+//
+//	c.Assert(1, IntNotEqual, 2)
 var IntNotEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntNotEqual", Params: []string{"a", "b"}}, rel: "!="}
 
 // IntGreaterThan checker verifies that one integer is greater than other integer.
 //
 // For example:
-//     c.Assert(2, IntGreaterThan, 1)
+//
+//	c.Assert(2, IntGreaterThan, 1)
 var IntGreaterThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterThan", Params: []string{"a", "b"}}, rel: ">"}
 
 // IntGreaterEqual checker verifies that one integer is greater than or equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntGreaterEqual, 2)
+//
+//	c.Assert(1, IntGreaterEqual, 2)
 var IntGreaterEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterEqual", Params: []string{"a", "b"}}, rel: ">="}

--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -228,6 +228,9 @@ func makeTar(entries []TarEntry) ([]byte, error) {
 func compressBytesZstd(input []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	writer, err := zstd.NewWriter(&buf)
+	if err != nil {
+		return nil, err
+	}
 	if _, err = writer.Write(input); err != nil {
 		return nil, err
 	}

--- a/internal/testutil/pkgdata_test.go
+++ b/internal/testutil/pkgdata_test.go
@@ -359,6 +359,7 @@ func (s *pkgdataSuite) TestMakeDeb(c *C) {
 
 	var tarBuf bytes.Buffer
 	zstdReader, err := zstd.NewReader(&tarZstdBuf)
+	c.Assert(err, IsNil)
 	size, err = zstdReader.WriteTo(&tarBuf)
 	c.Assert(err, IsNil)
 	c.Assert(int(size), testutil.IntGreaterThan, 0)

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -39,7 +38,7 @@ func TreeDump(dir string) map[string]string {
 			}
 			result["/"+path] = fmt.Sprintf("symlink %s", lpath)
 		case 0: // Regular
-			data, err := ioutil.ReadFile(fpath)
+			data, err := os.ReadFile(fpath)
 			if err != nil {
 				return fmt.Errorf("cannot read file: %w", err)
 			}


### PR DESCRIPTION
* CLA Check ensures that contributors sign the Canonical Contributor Licence Agreement (https://ubuntu.com/legal/contributors).
  * Uses [canonical/has-signed-canonical-cla](https://github.com/marketplace/actions/has-signed-canonical-cla).
* Various Linting Support has been added, with the help of [golangci-lint](https://golangci-lint.run/). The various linters' specification is mentioned here: https://golangci-lint.run/usage/linters/
  * Check bugs and unused code using `errcheck`, `unused` and `staticcheck`.
  * Check formatting with `go fmt ./...`.
* Security: scan for known vulnerabilities using [Trivy](https://github.com/aquasecurity/trivy).
