### PR TITLE
deb/extract: Extract with umask set to 0

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/blakesmith/ar"
 	"github.com/klauspost/compress/zstd"
@@ -103,6 +104,11 @@ func Extract(pkgReader io.Reader, options *ExtractOptions) (err error) {
 }
 
 func extractData(dataReader io.Reader, options *ExtractOptions) error {
+
+	oldUmask := syscall.Umask(0)
+	defer func() {
+		syscall.Umask(oldUmask)
+	}()
 
 	shouldExtract := func(pkgPath string) (globPath string, ok bool) {
 		if pkgPath == "" {

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -48,7 +48,7 @@ var extractTests = []extractTest{{
 		},
 	},
 	result: map[string]string{
-		"/tmp/":               "dir 01775",
+		"/tmp/":               "dir 01777",
 		"/usr/":               "dir 0755",
 		"/usr/bin/":           "dir 0755",
 		"/usr/bin/hello":      "file 0775 eaf29575",
@@ -263,7 +263,7 @@ var extractTests = []extractTest{{
 		"/etc/":     "dir 0755",
 		"/usr/":     "dir 0755",
 		"/usr/bin/": "dir 0755",
-		"/tmp/":     "dir 01775",
+		"/tmp/":     "dir 01777",
 	},
 }, {
 	summary: "Optional entries mixed in cannot be missing",


### PR DESCRIPTION
Permission bits passed to open(2) are AND-ed with current process umask.
Set umask to 0 at the beginning of extractData() and restore it at the
end, to extract files with desired permissions no matter what's the
current process umask.

How does dpkg do it? It invokes tar binary to extract data.tar.gz, and
tar sets current process umask to 0 if it's running as root. (See
--no-same-permissions in tar(1)).

Also fix expected permissions of /tmp from 01775 to 01777.