### PR TITLE
setup: Allow creating files with empty content

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -336,12 +336,12 @@ type yamlPackage struct {
 }
 
 type yamlPath struct {
-	Dir     bool   `yaml:"make"`
-	Mode    uint   `yaml:"mode"`
-	Copy    string `yaml:"copy"`
-	Text    string `yaml:"text"`
-	Symlink string `yaml:"symlink"`
-	Mutable bool   `yaml:"mutable"`
+	Dir     bool    `yaml:"make"`
+	Mode    uint    `yaml:"mode"`
+	Copy    string  `yaml:"copy"`
+	Text    *string `yaml:"text"`
+	Symlink string  `yaml:"symlink"`
+	Mutable bool    `yaml:"mutable"`
 
 	Until PathUntil `yaml:"until"`
 	Arch  yamlArch  `yaml:"arch"`
@@ -533,9 +533,9 @@ func parsePackage(baseDir, pkgName, pkgPath string, data []byte) (*Package, erro
 					}
 					kinds = append(kinds, DirPath)
 				}
-				if len(yamlPath.Text) > 0 {
+				if yamlPath.Text != nil {
 					kinds = append(kinds, TextPath)
-					info = yamlPath.Text
+					info = *yamlPath.Text
 				}
 				if len(yamlPath.Symlink) > 0 {
 					kinds = append(kinds, SymlinkPath)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -682,6 +682,40 @@ var setupTests = []setupTest{{
 			},
 		},
 	},
+}, {
+	summary: "Text can be empty",
+	input: map[string]string{
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+					contents:
+						/nonempty: {text: "foo"}
+						/empty: {text: ""}
+		`,
+	},
+	release: &setup.Release{
+		DefaultArchive: "ubuntu",
+
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Archive: "ubuntu",
+				Name:    "mypkg",
+				Path:    "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{
+					"myslice": {
+						Package: "mypkg",
+						Name:    "myslice",
+						Contents: map[string]setup.PathInfo{
+							"/nonempty": {Kind: "text", Info: "foo"},
+							"/empty":    {Kind: "text", Info: ""},
+						},
+					},
+				},
+			},
+		},
+	},
 }}
 
 const defaultChiselYaml = `


### PR DESCRIPTION
Turn yamlPath.Text into pointer to distinguish between unset and empty
text attribute of a path. This is mainly to allow setting empty text to
mutable paths.