### PR TITLE
Handle duplicate symlink in multiple slices of a package

### DIFF
--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -67,5 +67,23 @@ func createSymlink(o *CreateOptions) error {
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
+	fileinfo, err := os.Lstat(o.Path)
+	if err == nil {
+		if (fileinfo.Mode() & os.ModeSymlink) != 0 {
+			link, err := os.Readlink(o.Path)
+			if err != nil {
+				return err
+			}
+			if link == o.Link {
+				return nil
+			}
+		}
+		err = os.Remove(o.Path)
+		if err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	return os.Symlink(o.Link, o.Path)
 }


### PR DESCRIPTION
In the current code, a copyright file from a package is added to every
slice of that package. This went unnoticed because the file was silently
overwritten from successive slices of the same package. However, the
openssl's copyright file is a symlink to the libssl3's copyright file,
and creating a symlink on the same path for the second time fails. Fix
it by adding a copyright file to only the first slice of a package.