### PR TITLE
Add re (regex) module and allow listing of implicit directories

### DIFF
--- a/internal/scripts/export_test.go
+++ b/internal/scripts/export_test.go
@@ -1,0 +1,3 @@
+package scripts
+
+var LoadModule = loadModule

--- a/internal/scripts/re.go
+++ b/internal/scripts/re.go
@@ -1,0 +1,305 @@
+package scripts
+
+import (
+	"fmt"
+	"regexp"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var reModuleName = "re.star"
+
+var reModule = starlark.StringDict{
+	"re": &starlarkstruct.Module{
+		Name: "re",
+		Members: starlark.StringDict{
+			"compile": starlark.NewBuiltin("re.compile", reCompile),
+			"find":    starlark.NewBuiltin("re.find", reFind),
+			"findall": starlark.NewBuiltin("re.findall", reFindAll),
+			"split":   starlark.NewBuiltin("re.split", reSplit),
+			"sub":     starlark.NewBuiltin("re.sub", reSub),
+		},
+	},
+}
+
+func unmarshalInt(in starlark.Int) (int, error) {
+	var out int = 0
+	err := starlark.AsInt(in, &out)
+	return out, err
+}
+
+func regexpFind(regex *regexp.Regexp, str starlark.String) (starlark.Value, error) {
+	match := regex.FindStringSubmatchIndex(string(str))
+	if match == nil {
+		return nil, nil
+	}
+	return &reMatch{str: string(str), match: match}, nil
+}
+
+func regexpFindAll(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	matches := regex.FindAllStringSubmatchIndex(string(str), limitInt)
+	resultArray := make([]starlark.Value, len(matches))
+	for i, match := range matches {
+		resultArray[i] = &reMatch{str: string(str), match: match}
+	}
+	return starlark.NewList(resultArray), nil
+}
+
+func regexpSplit(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	parts := regex.Split(string(str), limitInt)
+	resultArray := make([]starlark.Value, len(parts))
+	for i, part := range parts {
+		resultArray[i] = starlark.String(part)
+	}
+	return starlark.NewList(resultArray), nil
+}
+
+func regexpSub(regex *regexp.Regexp, repl starlark.String, str starlark.String) (starlark.Value, error) {
+	return starlark.String(regex.ReplaceAllString(string(str), string(repl))), nil
+}
+
+func reCompile(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern starlark.String
+	if err := starlark.UnpackArgs("re.compile", args, kwargs, "pattern", &pattern); err != nil {
+		return starlark.None, err
+	}
+	return newRegex(pattern)
+}
+
+func reFind(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	if err := starlark.UnpackArgs("re.find", args, kwargs, "pattern", &pattern, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpFind(regex, str)
+}
+
+func reFindAll(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.findall", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpFindAll(regex, str, limit)
+}
+
+func reSplit(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.split", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpSplit(regex, str, limit)
+}
+
+func reSub(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, repl, str starlark.String
+	if err := starlark.UnpackArgs("re.sub", args, kwargs, "pattern", &pattern, "repl", &repl, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpSub(regex, repl, str)
+}
+
+// reMatchIterator
+
+type reMatchIterator struct {
+	m *reMatch
+	i int
+}
+
+var _ starlark.Iterator = (*reMatchIterator)(nil)
+
+func (it *reMatchIterator) Next(p *starlark.Value) bool {
+	if it.i < it.m.Len() {
+		*p = it.m.Index(it.i)
+		it.i++
+		return true
+	}
+	return false
+
+}
+func (it *reMatchIterator) Done() {}
+
+// reMatch
+
+type reMatch struct {
+	str   string
+	match []int
+}
+
+var _ starlark.Value = (*reMatch)(nil)
+
+func (m *reMatch) String() string {
+	return m.groupsInternal().String()
+}
+
+func (m *reMatch) Type() string {
+	return "re.Match"
+}
+
+func (m *reMatch) Freeze() {
+}
+
+func (m *reMatch) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: %s", m.Type())
+}
+
+func (m *reMatch) Truth() starlark.Bool {
+	return true
+}
+
+var _ starlark.Indexable = (*reMatch)(nil)
+
+func (m *reMatch) Index(i int) starlark.Value {
+	return starlark.String(m.str[m.match[2*i]:m.match[2*i+1]])
+}
+
+func (m *reMatch) Len() int {
+	return len(m.match) / 2
+}
+
+var _ starlark.Iterable = (*reMatch)(nil)
+
+func (m *reMatch) Iterate() starlark.Iterator {
+	return &reMatchIterator{m: m, i: 0}
+}
+
+var _ starlark.HasAttrs = (*reMatch)(nil)
+
+func (r *reMatch) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "groups":
+		return starlark.NewBuiltin("re.Match.groups", r.groups), nil
+	}
+	return nil, nil
+}
+
+func (r *reMatch) AttrNames() []string {
+	return []string{"groups"}
+}
+
+func (m *reMatch) groupsInternal() starlark.Value {
+	groups := make([]starlark.Value, m.Len(), m.Len())
+	for i := 0; i < m.Len(); i++ {
+		groups[i] = m.Index(i)
+	}
+	return starlark.Tuple(groups)
+}
+
+func (m *reMatch) groups(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	return m.groupsInternal(), nil
+}
+
+// reRegex
+
+type reRegex struct {
+	regex *regexp.Regexp
+}
+
+func newRegex(pattern starlark.String) (*reRegex, error) {
+	re, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return &reRegex{regex: re}, nil
+}
+
+var _ starlark.Value = (*reRegex)(nil)
+
+func (r *reRegex) String() string {
+	return r.regex.String()
+}
+
+func (r *reRegex) Type() string {
+	return "re.Regex"
+}
+
+func (r *reRegex) Freeze() {
+}
+
+func (r *reRegex) Hash() (uint32, error) {
+	return starlark.String(r.regex.String()).Hash()
+}
+
+func (r *reRegex) Truth() starlark.Bool {
+	return true
+}
+
+var _ starlark.HasAttrs = (*reRegex)(nil)
+
+func (r *reRegex) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "find":
+		return starlark.NewBuiltin("re.Regex.find", r.find), nil
+	case "findall":
+		return starlark.NewBuiltin("re.Regex.findall", r.findall), nil
+	case "split":
+		return starlark.NewBuiltin("re.Regex.split", r.split), nil
+	case "sub":
+		return starlark.NewBuiltin("re.Regex.sub", r.split), nil
+	}
+	return nil, nil
+}
+
+func (r *reRegex) AttrNames() []string {
+	return []string{"find", "findall", "split"}
+}
+
+func (r *reRegex) find(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	if err := starlark.UnpackArgs("re.Regex.find", args, kwargs, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	return regexpFind(r.regex, str)
+}
+
+func (r *reRegex) findall(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.Regex.findall", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexpFindAll(r.regex, str, limit)
+}
+
+func (r *reRegex) split(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.Regex.split", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexpSplit(r.regex, str, limit)
+}
+
+func (r *reRegex) sub(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var repl, str starlark.String
+	if err := starlark.UnpackArgs("re.Regex.sub", args, kwargs, "repl", &repl, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	return regexpSub(r.regex, repl, str)
+}

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -23,8 +23,17 @@ type RunOptions struct {
 	Script    string
 }
 
+func loadModule(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+	switch module {
+	case reModuleName:
+		return reModule, nil
+	default:
+		return nil, fmt.Errorf("no such module: %s", module)
+	}
+}
+
 func Run(opts *RunOptions) error {
-	thread := &starlark.Thread{Name: opts.Label}
+	thread := &starlark.Thread{Name: opts.Label, Load: loadModule}
 	globals, err := starlark.ExecFile(thread, opts.Label, opts.Script, opts.Namespace)
 	_ = globals
 	return err

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -200,6 +200,26 @@ var scriptsTests = []scriptsTest{{
 		return nil
 	},
 	error: `no write: /foo/file2.txt`,
+}, {
+	summary: "Create a symlink",
+	content: map[string]string{
+		"foo/file1.txt": `data1`,
+		"bar/file2.txt": `data2`,
+	},
+	script: `
+		content.symlink("file1.txt", "/foo/file1.link.txt")
+		content.symlink("/foo/file1.txt", "/bar/file1.link.txt")
+		content.symlink("bar/", "/bar.link")
+	`,
+	result: map[string]string{
+		"/foo/":               "dir 0755",
+		"/foo/file1.txt":      "file 0644 5b41362b",
+		"/foo/file1.link.txt": "symlink file1.txt",
+		"/bar/":               "dir 0755",
+		"/bar/file1.link.txt": "symlink /foo/file1.txt",
+		"/bar/file2.txt":      "file 0644 d98cf53e",
+		"/bar.link":           "symlink bar/",
+	},
 }}
 
 func (s *S) TestScripts(c *C) {

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -18,8 +18,8 @@ type scriptsTest struct {
 	hackdir func(c *C, dir string)
 	script  string
 	result  map[string]string
-	checkr  func(path string) error
-	checkw  func(path string) error
+	checkr  func(_ *scripts.ContentValue, path string) error
+	checkw  func(_ *scripts.ContentValue, path string) error
 	error   string
 }
 
@@ -127,7 +127,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.read("/foo/../bar/file2.txt")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/file2.txt`,
 }, {
 	summary: "Check writes",
@@ -138,7 +138,7 @@ var scriptsTests = []scriptsTest{{
 		content.read("/foo/../bar/file1.txt")
 		content.write("/foo/../bar/file1.txt", "data1")
 	`,
-	checkw: func(p string) error { return fmt.Errorf("no write: %s", p) },
+	checkw: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no write: %s", p) },
 	error:  `no write: /bar/file1.txt`,
 }, {
 	summary: "Check lists",
@@ -149,7 +149,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar/")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check lists",
@@ -160,7 +160,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check reads on symlinks",
@@ -174,7 +174,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.read("/foo/file1.txt")
 	`,
-	checkr: func(p string) error {
+	checkr: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no read: %s", p)
 		}
@@ -193,7 +193,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.write("/foo/file1.txt", "")
 	`,
-	checkw: func(p string) error {
+	checkw: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no write: %s", p)
 		}
@@ -243,6 +243,6 @@ func (s *S) TestScripts(c *C) {
 
 func (s *S) TestContentRelative(c *C) {
 	content := scripts.ContentValue{RootDir: "foo"}
-	_, err := content.RealPath("/bar", scripts.CheckNone)
+	_, err := content.RealPath("/bar", nil)
 	c.Assert(err, ErrorMatches, "internal error: content defined with relative root: foo")
 }

--- a/internal/scripts/testdata/re.star
+++ b/internal/scripts/testdata/re.star
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2018 QRI, Inc.
+# Copyright (c) 2022 Canonical Ltd.
+
+load("assert.star", "assert")
+load("re.star", "re")
+
+def test_find():
+    result = re.find(
+        r"(\w*)\s*(ADD|REM|DEL|EXT|TRF)\s*(.*)\s*(NAT|INT)\s*(.*)\s*(\(\w{2}\))\s*(.*)",
+        "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University"
+    )
+    assert.eq(result.groups(), (
+        "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University",
+        "EDM",
+        "ADD",
+        "FROM INJURED ",
+        "NAT",
+        "Jordan BEAULIEU ",
+        "(DB)",
+        "Western University",
+    ))
+
+def test_findall():
+    result = re.findall(
+        r"\b([A-Z])\w+",
+        "Alpha Bravo charlie DELTA Echo F Hotel",
+    )
+    result_groups = [m.groups() for m in result]
+    assert.eq(result_groups, [
+        ("Alpha", "A"),
+        ("Bravo", "B"),
+        ("DELTA", "D"),
+        ("Echo", "E"),
+        ("Hotel", "H"),
+    ])
+
+def test_split():
+    result = re.split(r"\s+", "  foo bar   baz\tqux quux ", 5)
+    assert.eq(result, ["", "foo", "bar", "baz", "qux quux "])
+
+def test_sub():
+    result = re.sub(r"[A-Z]+", "_", "aBcDEFefG")
+    assert.eq(result, "a_c_ef_")

--- a/internal/scripts/testdata_test.go
+++ b/internal/scripts/testdata_test.go
@@ -1,0 +1,62 @@
+package scripts_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+
+	"github.com/canonical/chisel/internal/scripts"
+)
+
+func testModuleLoader(thread *starlark.Thread, moduleName string) (starlark.StringDict, error) {
+	if moduleName == "assert.star" {
+		return starlarktest.LoadAssertModule()
+	}
+	return scripts.LoadModule(thread, moduleName)
+}
+
+func execStarFile(c *C, path string) starlark.StringDict {
+	thread := &starlark.Thread{Load: testModuleLoader}
+	starlarktest.SetReporter(thread, c)
+	env, err := starlark.ExecFile(thread, path, nil, nil)
+	c.Assert(err, IsNil)
+	return env
+}
+
+func callTestFunctions(c *C, env starlark.StringDict) {
+	for name, value := range env {
+		thread := &starlark.Thread{}
+		starlarktest.SetReporter(thread, c)
+		if value.Type() == "function" && strings.HasPrefix(name, "test_") {
+			_, err := starlark.Call(thread, value, []starlark.Value{}, []starlark.Tuple{})
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func runStarFileTest(c *C, path string) {
+	env := execStarFile(c, path)
+	callTestFunctions(c, env)
+}
+
+func runStarDirTest(c *C, dir string) {
+	fileList, err := ioutil.ReadDir(dir)
+	if err != nil {
+		c.Errorf("error listing directory %#v, ioutil.ReadDir: %v", dir, err)
+	}
+	for _, file := range fileList {
+		path := filepath.Join(dir, file.Name())
+		if strings.HasSuffix(path, ".star") {
+			runStarFileTest(c, path)
+		}
+	}
+}
+
+func (s *S) TestStarFiles(c *C) {
+	runStarDirTest(c, "testdata")
+}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -191,13 +191,13 @@ func Run(options *RunOptions) error {
 
 	// Run mutation scripts. Order is fundamental here as
 	// dependencies must run before dependents.
-	checkWrite := func(path string) error {
+	checkWrite := func(_ *scripts.ContentValue, path string) error {
 		if !pathInfos[path].Mutable {
 			return fmt.Errorf("cannot write file which is not mutable: %s", path)
 		}
 		return nil
 	}
-	checkRead := func(path string) error {
+	checkRead := func(_ *scripts.ContentValue, path string) error {
 		if _, ok := pathInfos[path]; !ok {
 			for globPath := range globbedPaths {
 				if strdist.GlobPath(globPath, path) {
@@ -237,7 +237,7 @@ func Run(options *RunOptions) error {
 				targetPaths = []string{targetPath}
 			}
 			for _, targetPath := range targetPaths {
-				realPath, err := content.RealPath(targetPath, scripts.CheckRead)
+				realPath, err := content.RealPath(targetPath, content.CheckRead)
 				if err == nil {
 					if strings.HasSuffix(targetPath, "/") {
 						untilDirs = append(untilDirs, realPath)


### PR DESCRIPTION
This set of changes makes the following PR possible: canonical/chisel-releases#20 Dotnet packages contain files under /usr/lib/dotnet/dotnet6-6.0.110. Package dotnet-host creates /usr/lib/dotnet/dotnet6 symlink via alternatives mechanism. We cannot create this symlink in chisel becase a) we don't have a Starlark functions for creating symlink and b) implicitly created parent directories were not marked as selected. Fix these two issues.

Please do not squash my PRs.