### PR TITLE
setup: Rename `ubuntuAnimals` to `ubuntuAdjectives`

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -384,7 +384,7 @@ type yamlSlice struct {
 	Mutate    string               `yaml:"mutate"`
 }
 
-var ubuntuAnimals = map[string]string{
+var ubuntuAdjectives = map[string]string{
 	"18.04": "bionic",
 	"20.04": "focal",
 	"22.04": "jammy",
@@ -426,11 +426,11 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			return nil, fmt.Errorf("%s: archive %q missing version field", fileName, archiveName)
 		}
 		if len(details.Suites) == 0 {
-			animal := ubuntuAnimals[details.Version]
-			if animal == "" {
+			adjective := ubuntuAdjectives[details.Version]
+			if adjective == "" {
 				return nil, fmt.Errorf("%s: archive %q missing suites field", fileName, archiveName)
 			}
-			details.Suites = []string{animal}
+			details.Suites = []string{adjective}
 		}
 		if len(details.Components) == 0 {
 			return nil, fmt.Errorf("%s: archive %q missing components field", fileName, archiveName)


### PR DESCRIPTION
It's actually a map from release number to adjective, not animal as it was named.

Closes #16