### PR TITLE
Allow listing of implicit directories and add content.symlink() method

### DIFF
--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -200,6 +200,26 @@ var scriptsTests = []scriptsTest{{
 		return nil
 	},
 	error: `no write: /foo/file2.txt`,
+}, {
+	summary: "Create a symlink",
+	content: map[string]string{
+		"foo/file1.txt": `data1`,
+		"bar/file2.txt": `data2`,
+	},
+	script: `
+		content.symlink("file1.txt", "/foo/file1.link.txt")
+		content.symlink("/foo/file1.txt", "/bar/file1.link.txt")
+		content.symlink("bar/", "/bar.link")
+	`,
+	result: map[string]string{
+		"/foo/":               "dir 0755",
+		"/foo/file1.txt":      "file 0644 5b41362b",
+		"/foo/file1.link.txt": "symlink file1.txt",
+		"/bar/":               "dir 0755",
+		"/bar/file1.link.txt": "symlink /foo/file1.txt",
+		"/bar/file2.txt":      "file 0644 d98cf53e",
+		"/bar.link":           "symlink bar/",
+	},
 }}
 
 func (s *S) TestScripts(c *C) {

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -18,8 +18,8 @@ type scriptsTest struct {
 	hackdir func(c *C, dir string)
 	script  string
 	result  map[string]string
-	checkr  func(path string) error
-	checkw  func(path string) error
+	checkr  func(_ *scripts.ContentValue, path string) error
+	checkw  func(_ *scripts.ContentValue, path string) error
 	error   string
 }
 
@@ -127,7 +127,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.read("/foo/../bar/file2.txt")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/file2.txt`,
 }, {
 	summary: "Check writes",
@@ -138,7 +138,7 @@ var scriptsTests = []scriptsTest{{
 		content.read("/foo/../bar/file1.txt")
 		content.write("/foo/../bar/file1.txt", "data1")
 	`,
-	checkw: func(p string) error { return fmt.Errorf("no write: %s", p) },
+	checkw: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no write: %s", p) },
 	error:  `no write: /bar/file1.txt`,
 }, {
 	summary: "Check lists",
@@ -149,7 +149,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar/")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check lists",
@@ -160,7 +160,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check reads on symlinks",
@@ -174,7 +174,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.read("/foo/file1.txt")
 	`,
-	checkr: func(p string) error {
+	checkr: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no read: %s", p)
 		}
@@ -193,7 +193,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.write("/foo/file1.txt", "")
 	`,
-	checkw: func(p string) error {
+	checkw: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no write: %s", p)
 		}
@@ -243,6 +243,6 @@ func (s *S) TestScripts(c *C) {
 
 func (s *S) TestContentRelative(c *C) {
 	content := scripts.ContentValue{RootDir: "foo"}
-	_, err := content.RealPath("/bar", scripts.CheckNone)
+	_, err := content.RealPath("/bar", nil)
 	c.Assert(err, ErrorMatches, "internal error: content defined with relative root: foo")
 }

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -191,13 +191,13 @@ func Run(options *RunOptions) error {
 
 	// Run mutation scripts. Order is fundamental here as
 	// dependencies must run before dependents.
-	checkWrite := func(path string) error {
+	checkWrite := func(_ *scripts.ContentValue, path string) error {
 		if !pathInfos[path].Mutable {
 			return fmt.Errorf("cannot write file which is not mutable: %s", path)
 		}
 		return nil
 	}
-	checkRead := func(path string) error {
+	checkRead := func(_ *scripts.ContentValue, path string) error {
 		if _, ok := pathInfos[path]; !ok {
 			for globPath := range globbedPaths {
 				if strdist.GlobPath(globPath, path) {
@@ -237,7 +237,7 @@ func Run(options *RunOptions) error {
 				targetPaths = []string{targetPath}
 			}
 			for _, targetPath := range targetPaths {
-				realPath, err := content.RealPath(targetPath, scripts.CheckRead)
+				realPath, err := content.RealPath(targetPath, content.CheckRead)
 				if err == nil {
 					if strings.HasSuffix(targetPath, "/") {
 						untilDirs = append(untilDirs, realPath)


### PR DESCRIPTION
This set of changes makes the following PR possible: https://github.com/canonical/chisel-releases/pull/20 Dotnet packages contain files under /usr/lib/dotnet/dotnet6-6.0.110. Package dotnet-host creates /usr/lib/dotnet/dotnet6 symlink via alternatives mechanism. We cannot create this symlink in chisel becase a) we don't have a Starlark functions for creating symlink and b) implicitly created parent directories were not marked as selected. Fix these two issues.

Please do not squash my PRs.