### PR TITLE
scripts: Add re.star module

### DIFF
--- a/internal/scripts/export_test.go
+++ b/internal/scripts/export_test.go
@@ -1,0 +1,3 @@
+package scripts
+
+var LoadModule = loadModule

--- a/internal/scripts/re.go
+++ b/internal/scripts/re.go
@@ -1,0 +1,305 @@
+package scripts
+
+import (
+	"fmt"
+	"regexp"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var reModuleName = "re.star"
+
+var reModule = starlark.StringDict{
+	"re": &starlarkstruct.Module{
+		Name: "re",
+		Members: starlark.StringDict{
+			"compile": starlark.NewBuiltin("re.compile", reCompile),
+			"find":    starlark.NewBuiltin("re.find", reFind),
+			"findall": starlark.NewBuiltin("re.findall", reFindAll),
+			"split":   starlark.NewBuiltin("re.split", reSplit),
+			"sub":     starlark.NewBuiltin("re.sub", reSub),
+		},
+	},
+}
+
+func unmarshalInt(in starlark.Int) (int, error) {
+	var out int = 0
+	err := starlark.AsInt(in, &out)
+	return out, err
+}
+
+func regexpFind(regex *regexp.Regexp, str starlark.String) (starlark.Value, error) {
+	match := regex.FindStringSubmatchIndex(string(str))
+	if match == nil {
+		return nil, nil
+	}
+	return &reMatch{str: string(str), match: match}, nil
+}
+
+func regexpFindAll(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	matches := regex.FindAllStringSubmatchIndex(string(str), limitInt)
+	resultArray := make([]starlark.Value, len(matches))
+	for i, match := range matches {
+		resultArray[i] = &reMatch{str: string(str), match: match}
+	}
+	return starlark.NewList(resultArray), nil
+}
+
+func regexpSplit(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	parts := regex.Split(string(str), limitInt)
+	resultArray := make([]starlark.Value, len(parts))
+	for i, part := range parts {
+		resultArray[i] = starlark.String(part)
+	}
+	return starlark.NewList(resultArray), nil
+}
+
+func regexpSub(regex *regexp.Regexp, repl starlark.String, str starlark.String) (starlark.Value, error) {
+	return starlark.String(regex.ReplaceAllString(string(str), string(repl))), nil
+}
+
+func reCompile(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern starlark.String
+	if err := starlark.UnpackArgs("re.compile", args, kwargs, "pattern", &pattern); err != nil {
+		return starlark.None, err
+	}
+	return newPatterng(pattern)
+}
+
+func reFind(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	if err := starlark.UnpackArgs("re.find", args, kwargs, "pattern", &pattern, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpFind(regex, str)
+}
+
+func reFindAll(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.findall", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpFindAll(regex, str, limit)
+}
+
+func reSplit(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.split", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpSplit(regex, str, limit)
+}
+
+func reSub(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, repl, str starlark.String
+	if err := starlark.UnpackArgs("re.sub", args, kwargs, "pattern", &pattern, "repl", &repl, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexpSub(regex, repl, str)
+}
+
+// reMatchIterator
+
+type reMatchIterator struct {
+	m *reMatch
+	i int
+}
+
+var _ starlark.Iterator = (*reMatchIterator)(nil)
+
+func (it *reMatchIterator) Next(p *starlark.Value) bool {
+	if it.i < it.m.Len() {
+		*p = it.m.Index(it.i)
+		it.i++
+		return true
+	}
+	return false
+
+}
+func (it *reMatchIterator) Done() {}
+
+// reMatch
+
+type reMatch struct {
+	str   string
+	match []int
+}
+
+var _ starlark.Value = (*reMatch)(nil)
+
+func (m *reMatch) String() string {
+	return m.groupsInternal().String()
+}
+
+func (m *reMatch) Type() string {
+	return "re.Match"
+}
+
+func (m *reMatch) Freeze() {
+}
+
+func (m *reMatch) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: %s", m.Type())
+}
+
+func (m *reMatch) Truth() starlark.Bool {
+	return true
+}
+
+var _ starlark.Indexable = (*reMatch)(nil)
+
+func (m *reMatch) Index(i int) starlark.Value {
+	return starlark.String(m.str[m.match[2*i]:m.match[2*i+1]])
+}
+
+func (m *reMatch) Len() int {
+	return len(m.match) / 2
+}
+
+var _ starlark.Iterable = (*reMatch)(nil)
+
+func (m *reMatch) Iterate() starlark.Iterator {
+	return &reMatchIterator{m: m, i: 0}
+}
+
+var _ starlark.HasAttrs = (*reMatch)(nil)
+
+func (r *reMatch) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "groups":
+		return starlark.NewBuiltin("re.Match.groups", r.groups), nil
+	}
+	return nil, nil
+}
+
+func (r *reMatch) AttrNames() []string {
+	return []string{"groups"}
+}
+
+func (m *reMatch) groupsInternal() starlark.Value {
+	groups := make([]starlark.Value, m.Len(), m.Len())
+	for i := 0; i < m.Len(); i++ {
+		groups[i] = m.Index(i)
+	}
+	return starlark.Tuple(groups)
+}
+
+func (m *reMatch) groups(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	return m.groupsInternal(), nil
+}
+
+// rePattern
+
+type rePattern struct {
+	regex *regexp.Regexp
+}
+
+func newPatterng(pattern starlark.String) (*rePattern, error) {
+	re, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return &rePattern{regex: re}, nil
+}
+
+var _ starlark.Value = (*rePattern)(nil)
+
+func (r *rePattern) String() string {
+	return r.regex.String()
+}
+
+func (r *rePattern) Type() string {
+	return "re.Pattern"
+}
+
+func (r *rePattern) Freeze() {
+}
+
+func (r *rePattern) Hash() (uint32, error) {
+	return starlark.String(r.regex.String()).Hash()
+}
+
+func (r *rePattern) Truth() starlark.Bool {
+	return true
+}
+
+var _ starlark.HasAttrs = (*rePattern)(nil)
+
+func (r *rePattern) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "find":
+		return starlark.NewBuiltin("re.Pattern.find", r.find), nil
+	case "findall":
+		return starlark.NewBuiltin("re.Pattern.findall", r.findall), nil
+	case "split":
+		return starlark.NewBuiltin("re.Pattern.split", r.split), nil
+	case "sub":
+		return starlark.NewBuiltin("re.Pattern.sub", r.split), nil
+	}
+	return nil, nil
+}
+
+func (r *rePattern) AttrNames() []string {
+	return []string{"find", "findall", "split"}
+}
+
+func (r *rePattern) find(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	if err := starlark.UnpackArgs("re.Pattern.find", args, kwargs, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	return regexpFind(r.regex, str)
+}
+
+func (r *rePattern) findall(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.Pattern.findall", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexpFindAll(r.regex, str, limit)
+}
+
+func (r *rePattern) split(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("re.Pattern.split", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexpSplit(r.regex, str, limit)
+}
+
+func (r *rePattern) sub(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var repl, str starlark.String
+	if err := starlark.UnpackArgs("re.Pattern.sub", args, kwargs, "repl", &repl, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	return regexpSub(r.regex, repl, str)
+}

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -23,8 +23,17 @@ type RunOptions struct {
 	Script    string
 }
 
+func loadModule(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+	switch module {
+	case reModuleName:
+		return reModule, nil
+	default:
+		return nil, fmt.Errorf("no such module: %s", module)
+	}
+}
+
 func Run(opts *RunOptions) error {
-	thread := &starlark.Thread{Name: opts.Label}
+	thread := &starlark.Thread{Name: opts.Label, Load: loadModule}
 	globals, err := starlark.ExecFile(thread, opts.Label, opts.Script, opts.Namespace)
 	_ = globals
 	return err

--- a/internal/scripts/testdata/re.star
+++ b/internal/scripts/testdata/re.star
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2018 QRI, Inc.
+# Copyright (c) 2022 Canonical Ltd.
+
+load("assert.star", "assert")
+load("re.star", "re")
+
+def test_find():
+    result = re.find(
+        r"(\w*)\s*(ADD|REM|DEL|EXT|TRF)\s*(.*)\s*(NAT|INT)\s*(.*)\s*(\(\w{2}\))\s*(.*)",
+        "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University"
+    )
+    assert.eq(result.groups(), (
+        "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University",
+        "EDM",
+        "ADD",
+        "FROM INJURED ",
+        "NAT",
+        "Jordan BEAULIEU ",
+        "(DB)",
+        "Western University",
+    ))
+
+def test_findall():
+    result = re.findall(
+        r"\b([A-Z])\w+",
+        "Alpha Bravo charlie DELTA Echo F Hotel",
+    )
+    result_groups = [m.groups() for m in result]
+    assert.eq(result_groups, [
+        ("Alpha", "A"),
+        ("Bravo", "B"),
+        ("DELTA", "D"),
+        ("Echo", "E"),
+        ("Hotel", "H"),
+    ])
+
+def test_split():
+    result = re.split(r"\s+", "  foo bar   baz\tqux quux ", 5)
+    assert.eq(result, ["", "foo", "bar", "baz", "qux quux "])
+
+def test_sub():
+    result = re.sub(r"[A-Z]+", "_", "aBcDEFefG")
+    assert.eq(result, "a_c_ef_")

--- a/internal/scripts/testdata_test.go
+++ b/internal/scripts/testdata_test.go
@@ -1,0 +1,62 @@
+package scripts_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+
+	"github.com/canonical/chisel/internal/scripts"
+)
+
+func testModuleLoader(thread *starlark.Thread, moduleName string) (starlark.StringDict, error) {
+	if moduleName == "assert.star" {
+		return starlarktest.LoadAssertModule()
+	}
+	return scripts.LoadModule(thread, moduleName)
+}
+
+func execStarFile(c *C, path string) starlark.StringDict {
+	thread := &starlark.Thread{Load: testModuleLoader}
+	starlarktest.SetReporter(thread, c)
+	env, err := starlark.ExecFile(thread, path, nil, nil)
+	c.Assert(err, IsNil)
+	return env
+}
+
+func callTestFunctions(c *C, env starlark.StringDict) {
+	for name, value := range env {
+		thread := &starlark.Thread{}
+		starlarktest.SetReporter(thread, c)
+		if value.Type() == "function" && strings.HasPrefix(name, "test_") {
+			_, err := starlark.Call(thread, value, []starlark.Value{}, []starlark.Tuple{})
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func runStarFileTest(c *C, path string) {
+	env := execStarFile(c, path)
+	callTestFunctions(c, env)
+}
+
+func runStarDirTest(c *C, dir string) {
+	fileList, err := ioutil.ReadDir(dir)
+	if err != nil {
+		c.Errorf("error listing directory %#v, ioutil.ReadDir: %v", dir, err)
+	}
+	for _, file := range fileList {
+		path := filepath.Join(dir, file.Name())
+		if strings.HasSuffix(path, ".star") {
+			runStarFileTest(c, path)
+		}
+	}
+}
+
+func (s *S) TestStarFiles(c *C) {
+	runStarDirTest(c, "testdata")
+}


### PR DESCRIPTION
Add common regular expression functions to "re" namespace in a new
"re.star" module.

The regular expression functions are implemented by regexp package[1]
from Go standard library, which implements a subset of RE2 syntax and is
guaranteed to run in time linear in the size of the input[2].

The exported regular expression API is modeled after Python 3 re module
[3], though only most commonly used (by author of this commit) subset of
re API is implemented. Specifically, compile, find, findall, split and
sub functions are implemented, and all but the first functions are also
implemented as methods on a re.Regex object returned from the compile
function. The find and findall functions return re.Match object which is
also modeled after Python 3 re module equivalent.

[1] https://pkg.go.dev/regexp
[2] https://cs.opensource.google/go/go/+/master:src/regexp/regexp.go;l=15
[3] https://docs.python.org/3/library/re.html

Example usage:

    load("re.star", "re")

    input_string = "abc 123"

    num_regex = re.compile("[0-9]+")
    match1 = num_regex.find(input_string)
    if match1:
        print("Found match:", match1.groups(0))

    match2 = re.find("[a-z]+", input_string)
    if match2:
        print("Found match:", match2.groups(0))

    quoted_alpha = re.sub("([a-z]+)", "'$1'", input_string)

