### PR TITLE
slicer: Fix checking directory paths for listing

### DIFF
--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -1,8 +1,8 @@
 package scripts
 
 import (
-	"go.starlark.net/starlark"
 	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
 
 	"fmt"
 	"io/ioutil"
@@ -98,7 +98,7 @@ func (c *ContentValue) RealPath(path string, what Check) (string, error) {
 		return "", fmt.Errorf("content path must be absolute, got: %s", path)
 	}
 	cpath := filepath.Clean(path)
-	if strings.HasSuffix(path, "/") {
+	if cpath != "/" && strings.HasSuffix(path, "/") {
 		cpath += "/"
 	}
 	if c.CheckRead != nil && what&CheckRead != 0 {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -232,10 +232,27 @@ func Run(options *RunOptions) error {
 		return nil
 	}
 	checkRead := func(path string) error {
+		var err error
 		if !knownPaths[path] {
-			return fmt.Errorf("cannot read file which is not selected: %s", path)
+			// we assume that path is clean and ends with slash if it designates a directory
+			if path[len(path)-1] == '/' {
+				if path == "/" {
+					panic("internal error: content root (\"/\") is not selected")
+				}
+				if knownPaths[path[:len(path)-1]] {
+					err = fmt.Errorf("content is not a directory: %s", path[:len(path)-1])
+				} else {
+					err = fmt.Errorf("cannot list directory which is not selected: %s", path)
+				}
+			} else {
+				if knownPaths[path+"/"] {
+					err = fmt.Errorf("content is not a file: %s", path)
+				} else {
+					err = fmt.Errorf("cannot read file which is not selected: %s", path)
+				}
+			}
 		}
-		return nil
+		return err
 	}
 	content := &scripts.ContentValue{
 		RootDir:    targetDirAbs,

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -84,6 +84,7 @@ func Run(options *RunOptions) error {
 		}
 		arch := archives[slice.Package].Options().Arch
 		copyrightPath := "/usr/share/doc/" + slice.Package + "/copyright"
+		addKnownPath(copyrightPath)
 		hasCopyright := false
 		for targetPath, pathInfo := range slice.Contents {
 			if targetPath == "" {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -92,7 +92,9 @@ func Run(options *RunOptions) error {
 			if len(pathInfo.Arch) > 0 && !contains(pathInfo.Arch, arch) {
 				continue
 			}
-			addKnownPath(targetPath)
+			if pathInfo.Kind != setup.GlobPath {
+				addKnownPath(targetPath)
+			}
 			pathInfos[targetPath] = pathInfo
 			if pathInfo.Kind == setup.CopyPath || pathInfo.Kind == setup.GlobPath {
 				sourcePath := pathInfo.Info

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -33,20 +33,24 @@ func Run(options *RunOptions) error {
 	knownPaths["/"] = true
 
 	addKnownPath := func(path string) {
-		path = filepath.Clean(path)
 		if path[0] != '/' {
 			panic("bug: tried to add relative path to known paths")
 		}
+		cleanPath := filepath.Clean(path)
+		slashPath := cleanPath
+		if path[len(path)-1] == '/' && cleanPath != "/" {
+			slashPath += "/"
+		}
 		for {
-			if _, ok := knownPaths[path]; ok {
+			if _, ok := knownPaths[slashPath]; ok {
 				break
 			}
-			knownPaths[path] = true
-			path = filepath.Dir(path)
-			if path == "/" {
+			knownPaths[slashPath] = true
+			cleanPath = filepath.Dir(cleanPath)
+			if cleanPath == "/" {
 				break
 			}
-			path += "/"
+			slashPath = cleanPath + "/"
 		}
 	}
 

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -453,6 +453,25 @@ var slicerTests = []slicerTest{{
 						/etc/ssl/openssl.cnf:
 		`,
 	},
+}, {
+	summary: "Can list unclean directory paths",
+	slices:  []setup.SliceKey{{"base-files", "myslice"}},
+	release: map[string]string{
+		"slices/mydir/base-files.yaml": `
+			package: base-files
+			slices:
+				myslice:
+					contents:
+						/a/b/c: {text: foo}
+						/x/y/: {make: true}
+					mutate: |
+						content.list("/////")
+						content.list("/a/")
+						content.list("/a/b/../b/")
+						content.list("/x///")
+						content.list("/x/./././y")
+		`,
+	},
 }}
 
 const defaultChiselYaml = `

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -383,7 +383,7 @@ var slicerTests = []slicerTest{{
 						content.list("/a/d")
 		`,
 	},
-	error: `slice base-files_myslice: cannot read file which is not selected: /a/d/`,
+	error: `slice base-files_myslice: cannot list directory which is not selected: /a/d/`,
 }, {
 	summary: "Cannot list file path as a directory",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -398,7 +398,7 @@ var slicerTests = []slicerTest{{
 						content.list("/a/b/c")
 		`,
 	},
-	error: `slice base-files_myslice: cannot read file which is not selected: /a/b/c/`,
+	error: `slice base-files_myslice: content is not a directory: /a/b/c`,
 }, {
 	summary: "Can list parent directories of globs",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -427,7 +427,7 @@ var slicerTests = []slicerTest{{
 						content.list("/etc")
 		`,
 	},
-	error: `slice base-files_myslice: cannot read file which is not selected: /etc/`,
+	error: `slice base-files_myslice: cannot list directory which is not selected: /etc/`,
 }, {
 	summary: "Duplicate copyright symlink is ignored",
 	slices:  []setup.SliceKey{{"copyright-symlink-openssl", "bins"}},
@@ -472,6 +472,21 @@ var slicerTests = []slicerTest{{
 						content.list("/x/./././y")
 		`,
 	},
+}, {
+	summary: "Cannot read directories",
+	slices:  []setup.SliceKey{{"base-files", "myslice"}},
+	release: map[string]string{
+		"slices/mydir/base-files.yaml": `
+			package: base-files
+			slices:
+				myslice:
+					contents:
+						/x/y/: {make: true}
+					mutate: |
+						content.read("/x/y")
+		`,
+	},
+	error: `slice base-files_myslice: content is not a file: /x/y`,
 }}
 
 const defaultChiselYaml = `

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -383,7 +383,7 @@ var slicerTests = []slicerTest{{
 						content.list("/a/d")
 		`,
 	},
-	error: `slice base-files_myslice: cannot read file which is not selected: /a/d`,
+	error: `slice base-files_myslice: cannot read file which is not selected: /a/d/`,
 }, {
 	summary: "Cannot list file path as a directory",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -398,7 +398,7 @@ var slicerTests = []slicerTest{{
 						content.list("/a/b/c")
 		`,
 	},
-	error: `slice base-files_myslice: readdirent /a/b/c: not a directory`,
+	error: `slice base-files_myslice: cannot read file which is not selected: /a/b/c/`,
 }, {
 	summary: "Can list parent directories of globs",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -427,7 +427,7 @@ var slicerTests = []slicerTest{{
 						content.list("/etc")
 		`,
 	},
-	error: `slice base-files_myslice: cannot read file which is not selected: /etc`,
+	error: `slice base-files_myslice: cannot read file which is not selected: /etc/`,
 }, {
 	summary: "Duplicate copyright symlink is ignored",
 	slices:  []setup.SliceKey{{"copyright-symlink-openssl", "bins"}},


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
In commit 93353383 ("slicer: Allow listing implicit parent directories") we started recording path for checking if they can be read from scripts. The paths were recorded with slash for directories. But there was a bug because `filepath.Dir("/foo/") == "/foo"`. There were other issues as well. Fix the handling of paths in slicer and scripts.