### PR TITLE
Fix `Reindent` on unindented inputs

### DIFF
--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -8,6 +8,10 @@ import (
 // Reindent deindents the provided strings and replace tabs by spaces,
 // so yaml inlined into tests work properly when decoded.
 func Reindent(in string) []byte {
+	if in != "" && in[0] != '\t' {
+		return []uint8(strings.ReplaceAll(in, "\t", "    ") + "\n")
+	}
+
 	var buf bytes.Buffer
 	var trim string
 	var trimSet bool
@@ -24,7 +28,7 @@ func Reindent(in string) []byte {
 			trimSet = true
 		}
 		trimmed := strings.TrimPrefix(line, trim)
-		if len(trimmed) == len(line) && trim != "" && strings.TrimLeft(line, "\t ") != "" {
+		if len(trimmed) == len(line) && strings.TrimLeft(line, "\t ") != "" {
 			panic("Line not indented consistently:\n" + line)
 		}
 		trimmed = strings.ReplaceAll(trimmed, "\t", "    ")

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -24,7 +24,7 @@ func Reindent(in string) []byte {
 			trimSet = true
 		}
 		trimmed := strings.TrimPrefix(line, trim)
-		if len(trimmed) == len(line) && trim != "" && strings.Trim(line, "\t ") != "" {
+		if len(trimmed) == len(line) && trim != "" && strings.TrimLeft(line, "\t ") != "" {
 			panic("Line not indented consistently:\n" + line)
 		}
 		trimmed = strings.ReplaceAll(trimmed, "\t", "    ")

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -10,19 +10,21 @@ import (
 func Reindent(in string) []byte {
 	var buf bytes.Buffer
 	var trim string
+	var trimSet bool
 	for _, line := range strings.Split(in, "\n") {
-		if trim == "" {
+		if !trimSet {
 			trimmed := strings.TrimLeft(line, "\t")
 			if trimmed == "" {
 				continue
 			}
-			if trimmed[0] == ' ' {
+			if len(trimmed) != len(line) && trimmed[0] == ' ' {
 				panic("Tabs and spaces mixed early on string:\n" + in)
 			}
 			trim = line[:len(line)-len(trimmed)]
+			trimSet = true
 		}
 		trimmed := strings.TrimPrefix(line, trim)
-		if len(trimmed) == len(line) && strings.Trim(line, "\t ") != "" {
+		if len(trimmed) == len(line) && trim != "" && strings.Trim(line, "\t ") != "" {
 			panic("Line not indented consistently:\n" + line)
 		}
 		trimmed = strings.ReplaceAll(trimmed, "\t", "    ")

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// Reindent deindents the provided string and replaces tabs with spaces
-// so yaml inlined into tests works properly when decoded.
+// Reindent deindents the provided strings and replace tabs by spaces,
+// so yaml inlined into tests work properly when decoded.
 func Reindent(in string) []byte {
 	var buf bytes.Buffer
 	var trim string

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// Reindent deindents the provided strings and replace tabs by spaces,
-// so yaml inlined into tests work properly when decoded.
+// Reindent deindents the provided string and replaces tabs with spaces
+// so yaml inlined into tests works properly when decoded.
 func Reindent(in string) []byte {
 	var buf bytes.Buffer
 	var trim string

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -8,10 +8,6 @@ import (
 // Reindent deindents the provided strings and replace tabs by spaces,
 // so yaml inlined into tests work properly when decoded.
 func Reindent(in string) []byte {
-	if in != "" && in[0] != '\t' {
-		return []uint8(strings.ReplaceAll(in, "\t", "    ") + "\n")
-	}
-
 	var buf bytes.Buffer
 	var trim string
 	var trimSet bool
@@ -26,6 +22,10 @@ func Reindent(in string) []byte {
 			}
 			trim = line[:len(line)-len(trimmed)]
 			trimSet = true
+
+			if trim == "" {
+				return []uint8(strings.ReplaceAll(in, "\t", "    ") + "\n")
+			}
 		}
 		trimmed := strings.TrimPrefix(line, trim)
 		if len(trimmed) == len(line) && strings.TrimLeft(line, "\t ") != "" {

--- a/internal/testutil/reindent.go
+++ b/internal/testutil/reindent.go
@@ -17,9 +17,10 @@ func Reindent(in string) []byte {
 			if trimmed == "" {
 				continue
 			}
-			if len(trimmed) != len(line) && trimmed[0] == ' ' {
-				panic("Tabs and spaces mixed early on string:\n" + in)
+			if trimmed[0] == ' ' {
+				panic("Space used in indent early in string:\n" + in)
 			}
+
 			trim = line[:len(line)-len(trimmed)]
 			trimSet = true
 

--- a/internal/testutil/reindent_test.go
+++ b/internal/testutil/reindent_test.go
@@ -55,13 +55,11 @@ func (s *S) TestReindent(c *C) {
 func (*S) testReindent(c *C, test reindentTest) {
 	defer func() {
 		if err := recover(); err != nil {
-			msg, ok := err.(string)
+			errMsg, ok := err.(string)
 			if !ok {
 				panic(err)
 			}
-			if msg != test.err {
-				c.Errorf("Unexpected error: %#v", err)
-			}
+			c.Assert(errMsg, Equals, test.err)
 		}
 	}()
 

--- a/internal/testutil/reindent_test.go
+++ b/internal/testutil/reindent_test.go
@@ -1,0 +1,80 @@
+package testutil_test
+
+import (
+	"strings"
+
+	"github.com/canonical/chisel/internal/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type reindentTest struct {
+	src, expect, err string
+}
+
+var reindentTests = []reindentTest{{
+	src:    "a\nb",
+	expect: "a\nb",
+}, {
+	src:    "\ta\n\tb",
+	expect: "a\nb",
+}, {
+	src:    "    a\n    b",
+	expect: "    a\n    b",
+}, {
+	src:    "a\n\tb\nc",
+	expect: "a\n    b\nc",
+}, {
+	src:    "a\n  b\nc",
+	expect: "a\n  b\nc",
+}, {
+	src:    "\ta\n\t\tb\n\tc",
+	expect: "a\n    b\nc",
+}, {
+	src:    "  a\n    b\n  c",
+	expect: "  a\n    b\n  c",
+}, {
+	src:    "    a\n    \tb\n    c",
+	expect: "    a\n        b\n    c",
+}, {
+	src: "\t  a",
+	err: "Tabs and spaces mixed early on string:\n\t  a",
+}, {
+	src: "\t  a\n\t    b\n\t  c",
+	err: "Tabs and spaces mixed early on string:\n\t  a\n\t    b\n\t  c",
+}, {
+	src: "\ta\nb",
+	err: "Line not indented consistently:\nb",
+}}
+
+func (s *S) TestReindent(c *C) {
+	for _, test := range reindentTests {
+		s.testReindent(c, test)
+	}
+}
+
+func (*S) testReindent(c *C, test reindentTest) {
+	defer func() {
+		if err := recover(); err != nil {
+			msg, ok := err.(string)
+			if !ok {
+				panic(err)
+			}
+			if msg != test.err {
+				c.Errorf("Unexpected error: %#v", err)
+			}
+		}
+	}()
+
+	c.Logf("Test: %#v", test)
+
+	if !strings.HasSuffix(test.expect, "\n") {
+		test.expect += "\n"
+	}
+
+	reindented := testutil.Reindent(test.src)
+	if test.err != "" {
+		c.Errorf("Expected panic with message '%#v'", test.err)
+		return
+	}
+	c.Assert(string(reindented), Equals, test.expect)
+}

--- a/internal/testutil/reindent_test.go
+++ b/internal/testutil/reindent_test.go
@@ -8,42 +8,42 @@ import (
 )
 
 type reindentTest struct {
-	src, expect, err string
+	raw, result, error string
 }
 
 var reindentTests = []reindentTest{{
-	src:    "a\nb",
-	expect: "a\nb",
+	raw:    "a\nb",
+	result: "a\nb",
 }, {
-	src:    "\ta\n\tb",
-	expect: "a\nb",
+	raw:    "\ta\n\tb",
+	result: "a\nb",
 }, {
-	src:    "    a\n    b",
-	expect: "    a\n    b",
+	raw:    "    a\n    b",
+	result: "    a\n    b",
 }, {
-	src:    "a\n\tb\nc",
-	expect: "a\n    b\nc",
+	raw:    "a\n\tb\nc",
+	result: "a\n    b\nc",
 }, {
-	src:    "a\n  b\nc",
-	expect: "a\n  b\nc",
+	raw:    "a\n  b\nc",
+	result: "a\n  b\nc",
 }, {
-	src:    "\ta\n\t\tb\n\tc",
-	expect: "a\n    b\nc",
+	raw:    "\ta\n\t\tb\n\tc",
+	result: "a\n    b\nc",
 }, {
-	src:    "  a\n    b\n  c",
-	expect: "  a\n    b\n  c",
+	raw:    "  a\n    b\n  c",
+	result: "  a\n    b\n  c",
 }, {
-	src:    "    a\n    \tb\n    c",
-	expect: "    a\n        b\n    c",
+	raw:    "    a\n    \tb\n    c",
+	result: "    a\n        b\n    c",
 }, {
-	src: "\t  a",
-	err: "Tabs and spaces mixed early on string:\n\t  a",
+	raw:   "\t  a",
+	error: "Tabs and spaces mixed early on string:\n\t  a",
 }, {
-	src: "\t  a\n\t    b\n\t  c",
-	err: "Tabs and spaces mixed early on string:\n\t  a\n\t    b\n\t  c",
+	raw:   "\t  a\n\t    b\n\t  c",
+	error: "Tabs and spaces mixed early on string:\n\t  a\n\t    b\n\t  c",
 }, {
-	src: "\ta\nb",
-	err: "Line not indented consistently:\nb",
+	raw:   "\ta\nb",
+	error: "Line not indented consistently:\nb",
 }}
 
 func (s *S) TestReindent(c *C) {
@@ -59,20 +59,20 @@ func (*S) testReindent(c *C, test reindentTest) {
 			if !ok {
 				panic(err)
 			}
-			c.Assert(errMsg, Equals, test.err)
+			c.Assert(errMsg, Equals, test.error)
 		}
 	}()
 
 	c.Logf("Test: %#v", test)
 
-	if !strings.HasSuffix(test.expect, "\n") {
-		test.expect += "\n"
+	if !strings.HasSuffix(test.result, "\n") {
+		test.result += "\n"
 	}
 
-	reindented := testutil.Reindent(test.src)
-	if test.err != "" {
-		c.Errorf("Expected panic with message '%#v'", test.err)
+	reindented := testutil.Reindent(test.raw)
+	if test.error != "" {
+		c.Errorf("Expected panic with message '%#v'", test.error)
 		return
 	}
-	c.Assert(string(reindented), Equals, test.expect)
+	c.Assert(string(reindented), Equals, test.result)
 }

--- a/internal/testutil/reindent_test.go
+++ b/internal/testutil/reindent_test.go
@@ -18,9 +18,6 @@ var reindentTests = []reindentTest{{
 	raw:    "\ta\n\tb",
 	result: "a\nb",
 }, {
-	raw:    "    a\n    b",
-	result: "    a\n    b",
-}, {
 	raw:    "a\n\tb\nc",
 	result: "a\n    b\nc",
 }, {
@@ -30,17 +27,14 @@ var reindentTests = []reindentTest{{
 	raw:    "\ta\n\t\tb\n\tc",
 	result: "a\n    b\nc",
 }, {
-	raw:    "  a\n    b\n  c",
-	result: "  a\n    b\n  c",
-}, {
-	raw:    "    a\n    \tb\n    c",
-	result: "    a\n        b\n    c",
-}, {
 	raw:   "\t  a",
-	error: "Tabs and spaces mixed early on string:\n\t  a",
+	error: "Space used in indent early in string:\n\t  a",
 }, {
 	raw:   "\t  a\n\t    b\n\t  c",
-	error: "Tabs and spaces mixed early on string:\n\t  a\n\t    b\n\t  c",
+	error: "Space used in indent early in string:\n\t  a\n\t    b\n\t  c",
+}, {
+	raw:   "    a\nb",
+	error: "Space used in indent early in string:\n    a\nb",
 }, {
 	raw:   "\ta\nb",
 	error: "Line not indented consistently:\nb",

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -25,6 +25,10 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
+type S struct{}
+
+var _ = check.Suite(&S{})
+
 func testInfo(c *check.C, checker check.Checker, name string, paramNames []string) {
 	info := checker.Info()
 	if info.Name != name {


### PR DESCRIPTION
Fix problem where the `Reindent` function would panic when an unindented first line was followed by a mix of indented and unindented lines such as the following.
```go
testutil.Reindent(`
a
    b
c
`)
```
