### PR TITLE
fsutil/create_test: Run with umask 0

### DIFF
--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/fs"
 	"path/filepath"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
@@ -57,6 +58,10 @@ var createTests = []createTest{{
 }}
 
 func (s *S) TestCreate(c *C) {
+	oldUmask := syscall.Umask(0)
+	defer func() {
+		syscall.Umask(oldUmask)
+	}()
 
 	for _, test := range createTests {
 		c.Logf("Options: %v", test.options)


### PR DESCRIPTION
We assume that umask is 002 in fsutil/create_test similarly to what
69ef992 ("deb/extract: Extract with umask set to 0") fixed. Set umask 0
for duration of the test.


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----