### PR TITLE
Add support for pro archives

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -91,11 +91,14 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Suites:     archiveInfo.Suites,
 			Components: archiveInfo.Components,
 			CacheDir:   cache.DefaultDir("chisel"),
+			Pro:        archiveInfo.Pro,
 		})
 		if err != nil {
 			return err
 		}
-		archives[archiveName] = openArchive
+		if openArchive != nil {
+			archives[archiveName] = openArchive
+		}
 	}
 
 	return slicer.Run(&slicer.RunOptions{

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -92,6 +92,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Components: archiveInfo.Components,
 			CacheDir:   cache.DefaultDir("chisel"),
 			Pro:        archiveInfo.Pro,
+			Priority:   archiveInfo.Priority,
 		})
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,22 @@
 module github.com/canonical/chisel
 
-go 1.18
+go 1.20
 
 require (
+	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
+	github.com/jessevdk/go-flags v1.5.0
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
+	github.com/klauspost/compress v1.15.4
+	github.com/ulikunitz/xz v0.5.10
+	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd
+	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99
 )
 
 require (
-	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb // indirect
-	github.com/jessevdk/go-flags v1.5.0 // indirect
-	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
-	github.com/klauspost/compress v1.15.4 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.1.0 // indirect
-	github.com/ulikunitz/xz v0.5.10 // indirect
-	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd // indirect
-	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -29,9 +29,6 @@ type Options struct {
 }
 
 func Open(options *Options) (Archive, error) {
-	if options.Label != "ubuntu" {
-		return nil, fmt.Errorf("non-ubuntu archives are not supported yet")
-	}
 	var err error
 	if options.Arch == "" {
 		options.Arch, err = deb.InferArch()

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -28,6 +28,7 @@ type Options struct {
 	Components []string
 	CacheDir   string
 	Pro        string
+	Priority   int
 }
 
 func Open(options *Options) (Archive, error) {

--- a/internal/archive/credentials.go
+++ b/internal/archive/credentials.go
@@ -17,8 +17,8 @@ import (
 // credentials in Apt configuration, see
 // https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html.
 
-// credentials represents matched Username and Password if Username is
-// non-empty or unsuccessful search otherwise.
+// credentials contains matched non-empty Username and Password.
+// Username is left empty if the search is unsuccessful.
 type credentials struct {
 	Username string
 	Password string

--- a/internal/archive/credentials.go
+++ b/internal/archive/credentials.go
@@ -1,0 +1,297 @@
+package archive
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// This file defines findCredentials() function for searching repository
+// credentials in Apt configuration, see
+// https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html.
+
+// credentials represents matched Username and Password if Username is
+// non-empty or unsuccessful search otherwise.
+type credentials struct {
+	Username string
+	Password string
+}
+
+// Empty checks whether c represents unsuccessful search.
+func (c credentials) Empty() bool {
+	return c.Username == ""
+}
+
+// credentialsLookup contains parsed input URL data used for search.
+type credentialsLookup struct {
+	scheme     string
+	host       string
+	port       string
+	path       string
+	needScheme bool
+}
+
+// lookupFor parses repoUrl into credentialsLookup and fills provided credentials with
+// username and password if they are specified in repoUrl.
+func lookupFor(repoUrl string, creds *credentials) (*credentialsLookup, error) {
+	u, err := url.Parse(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+	host := u.Host
+	port := u.Port()
+	if port != "" {
+		// u.Hostname() would remove brackets from IPv6 address but we
+		// need it verbatim for string comparison in netrc file. This
+		// is also a bit faster because both u.Port() and u.Hostname()
+		// split u.Host into port and hostname.
+		host = u.Host[0 : len(u.Host)-len(port)-1]
+	}
+
+	lookup := credentialsLookup{
+		scheme:     u.Scheme,
+		host:       host,
+		port:       port,
+		path:       u.Path,
+		// If the input URL specifies unencrypted scheme, the scheme in
+		// machine declarations in netrc file is not optional and must
+		// also match.
+		needScheme: u.Scheme != "https" && u.Scheme != "tor+https",
+	}
+
+	if creds != nil {
+		creds.Username = u.User.Username()
+		creds.Password, _ = u.User.Password()
+	}
+
+	return &lookup, nil
+}
+
+// findCredentials searches credentials for repoUrl in configuration files in
+// directory specified by CHISEL_AUTH_DIR environment variable if it's
+// non-empty or /etc/apt/auth.conf.d.
+func findCredentials(repoUrl string) (credentials, error) {
+	credentialsDir := "/etc/apt/auth.conf.d"
+	if v := os.Getenv("CHISEL_AUTH_DIR"); v != "" {
+		credentialsDir = v
+	}
+	return findCredentialsDir(repoUrl, credentialsDir)
+}
+
+// findCredentialsDir searches for credentials for repoUrl in configuration
+// files in credentialsDir directory. If the directory does not exist, empty
+// credentials structure with nil err is returned.
+// Only files that do not begin with dot and have either no or ".conf"
+// extension are searched. The files are searched in ascending lexicographic
+// order. The first file that contains machine declaration matching repoUrl
+// ends the search. If no file contain matching machine declaration, empty
+// credentials structure with nil err is returned.
+func findCredentialsDir(repoUrl string, credentialsDir string) (creds credentials, err error) {
+	contents, err := os.ReadDir(credentialsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		} else {
+			err = fmt.Errorf("cannot open credentials directory: %w", err)
+		}
+		return
+	}
+
+	confFiles := make([]string, 0, len(contents))
+	for _, entry := range contents {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		var info fs.FileInfo
+		info, err = entry.Info()
+		if err != nil {
+			return
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		ext := filepath.Ext(name)
+		if ext == "" || ext == ".conf" {
+			confFiles = append(confFiles, name)
+		}
+	}
+	sort.Strings(confFiles)
+
+	lookup, err := lookupFor(repoUrl, &creds)
+	if err != nil {
+		return
+	}
+
+	errs := make([]error, 0, len(confFiles))
+
+	for _, file := range confFiles {
+		if !creds.Empty() {
+			break
+		}
+
+		f, err := os.Open(filepath.Join(credentialsDir, file))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("cannot read credentials file: %w", err))
+			continue
+		}
+
+		if err = findCredentialsFile(lookup, f, &creds); err != nil {
+			errs = append(errs, fmt.Errorf("cannot find credentials: %w", err))
+		}
+	}
+
+	err = errors.Join(errs...)
+	return
+}
+
+type netrcParser struct {
+	lookup  *credentialsLookup
+	scanner *bufio.Scanner
+	creds   *credentials
+}
+
+// findCredentialsFile searches for credentials in netrc file matching lookup
+// and fills creds with matched credentials if there's a match. The first match
+// ends the search.
+//
+// The format of the netrc file is described in [1]. The parser is adapted from
+// the Apt parser (see [2]). When the parser is looking for a matching machine
+// declaration it disregards the current context and only considers the input
+// token. For example when given the following netrc file
+//
+//   machine http://acme.com/foo login u1 password machine
+//   machine http://acme.com/bar login u2 password p2
+//
+// and http://acme.com/bar input URL, the second line won't match, because the
+// second "machine" will be treated as start of machine declaration. This also
+// means unknown tokens are ignored, so comments are not treated specially.
+//
+// When a matching machine declaration is encountered the search stops when a
+// next machine declaration is encountered or when end of file is reached. This
+// means that arbitrary number of login and password declarations (or in fact,
+// any tokens) can follow a machine declaration. The last declaration overrides
+// the previous ones. For example when given the following netrc file
+//
+//   machine http://acme.com login a login b password c login d password e
+//
+// and http://acme.com input URL, the matched username and password will be "d"
+// and "e" respectively.
+//
+// This parser diverges from the Apt parser in the following ways:
+//   1. The port specification in machine declaration is optional whether or
+//      not a path is specified. While the Apt documentation[1] implies the
+//      same behavior, the code adheres to it only when the machine declaration
+//      does not specify a path, see line 96 in [2].
+//   2. When the input URL has unencrypted scheme and the machine declaration
+//      does not specify a scheme, it is skipped silently. The Apt parser warns
+//      the user about it, see line 113 in [2].
+//
+// References:
+//   [1] https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html
+//   [2] https://salsa.debian.org/apt-team/apt/-/blob/d9039b24/apt-pkg/contrib/netrc.cc
+//   [3] https://salsa.debian.org/apt-team/apt/-/blob/4e04cbaf/methods/aptmethod.h#L560
+//   [4] https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
+//   [5] https://daniel.haxx.se/blog/2022/05/31/netrc-pains/
+
+func findCredentialsFile(lookup *credentialsLookup, netrc io.Reader, creds *credentials) error {
+	s := bufio.NewScanner(netrc)
+	s.Split(bufio.ScanWords)
+	p := netrcParser{
+		lookup:  lookup,
+		scanner: s,
+		creds:   creds,
+	}
+	var err error
+	for state := netrcInvalid; state != nil; {
+		state, err = state(&p)
+	}
+	if err := p.scanner.Err(); err != nil {
+		return err
+	}
+	return err
+}
+
+type netrcState func(*netrcParser) (netrcState, error)
+
+func netrcInvalid(p *netrcParser) (netrcState, error) {
+	for p.scanner.Scan() {
+		if p.scanner.Text() == "machine" {
+			return netrcMachine, nil
+		}
+	}
+	return nil, nil
+}
+
+func netrcMachine(p *netrcParser) (netrcState, error) {
+	if !p.scanner.Scan() {
+		return nil, errors.New("syntax error: reached end of file while expecting machine text")
+	}
+	token := p.scanner.Text()
+	if i := strings.Index(token, "://"); i != -1 {
+		if token[0:i] != p.lookup.scheme {
+			return netrcInvalid, nil
+		}
+		token = token[i+3:]
+	} else if p.lookup.needScheme {
+		return netrcInvalid, nil
+	}
+	if !strings.HasPrefix(token, p.lookup.host) {
+		return netrcInvalid, nil
+	}
+	token = token[len(p.lookup.host):]
+	if len(token) > 0 {
+		if token[0] == ':' {
+			if p.lookup.port == "" {
+				return netrcInvalid, nil
+			}
+			token = token[1:]
+			if !strings.HasPrefix(token, p.lookup.port) {
+				return netrcInvalid, nil
+			}
+			token = token[len(p.lookup.port):]
+		}
+		if !strings.HasPrefix(p.lookup.path, token) {
+			return netrcInvalid, nil
+		}
+	}
+	return netrcGoodMachine, nil
+}
+
+func netrcGoodMachine(p *netrcParser) (netrcState, error) {
+loop:
+	for p.scanner.Scan() {
+		switch p.scanner.Text() {
+		case "login":
+			return netrcUsername, nil
+		case "password":
+			return netrcPassword, nil
+		case "machine":
+			break loop
+		}
+	}
+	return nil, nil
+}
+
+func netrcUsername(p *netrcParser) (netrcState, error) {
+	if !p.scanner.Scan() {
+		return nil, errors.New("syntax error: reached end of file while expecting username text")
+	}
+	p.creds.Username = p.scanner.Text()
+	return netrcGoodMachine, nil
+}
+
+func netrcPassword(p *netrcParser) (netrcState, error) {
+	if !p.scanner.Scan() {
+		return nil, errors.New("syntax error: reached end of file while expecting password text")
+	}
+	p.creds.Password = p.scanner.Text()
+	return netrcGoodMachine, nil
+}

--- a/internal/archive/credentials_test.go
+++ b/internal/archive/credentials_test.go
@@ -1,0 +1,168 @@
+package archive_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/archive"
+)
+
+type matchTest struct {
+	url      string
+	err      string
+	username string
+	password string
+}
+
+type credentialsTest struct {
+	summary    string
+	authDir    map[string]string
+	matchTests []matchTest
+}
+
+var credentialsTests = []credentialsTest{{
+	summary: "Parsing",
+	authDir: map[string]string{
+		"50test-logins": `
+machine example.netter login bar password foo
+machine example.net login foo password bar
+
+machine example.org:90 login apt password apt
+machine	example.org:8080
+login
+example	password 	 foobar
+
+machine example.org
+login anonymous
+password pass
+
+machine example.com/foo login user1 unknown token password pass1
+machine example.com/bar password pass2 login user2
+		unknown token
+machine example.com/user login user
+machine example.netter login unused password firstentry
+machine socks5h://example.last/debian login debian password rules
+`,
+	},
+	matchTests: []matchTest{
+		{"https://example.net/foo", "", "foo", "bar"},
+		{"https://user:pass@example.net/foo", "", "user", "pass"},
+		{"https://example.org:90/foo", "", "apt", "apt"},
+		{"https://example.org:8080/foo", "", "example", "foobar"},
+		{"https://example.net:42/foo", "", "foo", "bar"},
+		{"https://example.org/foo", "", "anonymous", "pass"},
+		{"https://example.com/apt", "", "", ""},
+		{"https://example.com/foo", "", "user1", "pass1"},
+		{"https://example.com/fooo", "", "user1", "pass1"},
+		{"https://example.com/fo", "", "", ""},
+		{"https://example.com/bar", "", "user2", "pass2"},
+		{"https://example.com/user", "", "user", ""},
+		{"socks5h://example.last/debian", "", "debian", "rules"},
+		{"socks5h://example.debian/", "", "", ""},
+		{"socks5h://user:pass@example.debian/", "", "user", "pass"},
+	},
+}, {
+	summary: "Bad file: No machine",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+foo example.org login foo1 password bar
+machin example.org login foo2 password bar
+machine2 example.org login foo3 password bar
+`,
+	},
+	matchTests: []matchTest{
+		{"https://example.org/foo", "", "", ""},
+	},
+}, {
+	summary: "Bad file: Ends machine",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+machine example.org login foo1 password bar
+machine`,
+	},
+	matchTests: []matchTest{
+		{"https://example.org/foo", "", "foo1", "bar"},
+		{"https://example.net/foo", ".*\\breached end of file while expecting machine text\\b.*", "", ""},
+		{"https://foo:bar@example.net/foo", "", "foo", "bar"},
+	},
+}, {
+	summary: "Bad file: Ends login",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+machine example.org login foo1 password bar
+machine example.net login
+`,
+	},
+	matchTests: []matchTest{
+		{"https://example.org/foo", "", "foo1", "bar"},
+		{"https://example.net/foo", ".*\\breached end of file while expecting username text\\b.*", "", ""},
+		{"https://foo:bar@example.net/foo", "", "foo", "bar"},
+	},
+}, {
+	summary: "Matches only HTTPS",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+machine https.example login foo1 password bar
+machine http://http.example login foo1 password bar
+`,
+	},
+	matchTests: []matchTest{
+		{"https://https.example/foo", "", "foo1", "bar"},
+		{"http://https.example/foo", "", "", ""},
+		{"http://http.example/foo", "", "foo1", "bar"},
+		{"https://http.example/foo", "", "", ""},
+	},
+}, {
+	summary: "Password is machine",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+machine http://site1.com login u1 password machine
+machine http://site2.com login u2 password p2
+`,
+	},
+	matchTests: []matchTest{
+		{"http://site1.com/foo", "", "u1", "machine"},
+		{"http://site2.com/bar", "", "", ""},
+	},
+}, {
+	summary: "Multiple login and password tokens",
+	authDir: map[string]string{
+		"50test-logins.conf": `
+machine http://site1.com login a login b password c login d password e
+machine http://site2.com login f password g
+`,
+	},
+	matchTests: []matchTest{
+		{"http://site1.com/foo", "", "d", "e"},
+		{"http://site2.com/bar", "", "f", "g"},
+	},
+
+}}
+
+func (s *S) TestNetrcParser(c *C) {
+	for _, credentialsTest := range credentialsTests {
+		authDir := c.MkDir()
+		for path, data := range credentialsTest.authDir {
+			fpath := filepath.Join(authDir, path)
+			err := os.MkdirAll(filepath.Dir(fpath), 0755)
+			c.Assert(err, IsNil)
+			err = ioutil.WriteFile(fpath, []byte(data), 0644)
+			c.Assert(err, IsNil)
+		}
+
+		for _, matchTest := range credentialsTest.matchTests {
+			c.Logf("Summary: %s for URL %s", credentialsTest.summary, matchTest.url)
+			creds, err := archive.FindCredentialsDir(matchTest.url, authDir)
+			if matchTest.err != "" {
+				c.Assert(err, ErrorMatches, matchTest.err)
+			} else {
+				c.Assert(err, IsNil)
+			}
+			c.Assert(creds.Username, Equals, matchTest.username)
+			c.Assert(creds.Password, Equals, matchTest.password)
+		}
+	}
+}

--- a/internal/archive/export_test.go
+++ b/internal/archive/export_test.go
@@ -14,3 +14,6 @@ func FakeDo(do func(req *http.Request) (*http.Response, error)) (restore func())
 		bulkDo = _bulkDo
 	}
 }
+
+type Credentials = credentials
+var FindCredentialsDir = findCredentialsDir

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -413,15 +413,8 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 	if len(yamlVar.Archives) == 0 {
 		return nil, fmt.Errorf("%s: no archives defined", fileName)
 	}
-	if len(yamlVar.Archives) > 1 {
-		return nil, fmt.Errorf("%s: multiple archives not yet supported", fileName)
-	}
 
 	for archiveName, details := range yamlVar.Archives {
-		const ubuntuArchive = "ubuntu"
-		if archiveName != ubuntuArchive {
-			return nil, fmt.Errorf("%s: only %q archives are supported for now", fileName, ubuntuArchive)
-		}
 		if details.Version == "" {
 			return nil, fmt.Errorf("%s: archive %q missing version field", fileName, archiveName)
 		}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -30,6 +30,7 @@ type Archive struct {
 	Version    string
 	Suites     []string
 	Components []string
+	Pro        string
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -323,10 +324,11 @@ type yamlRelease struct {
 const yamlReleaseFormat = "chisel-v1"
 
 type yamlArchive struct {
-	Version    string   `yaml:"version"`
-	Suites     []string `yaml:"suites"`
-	Components []string `yaml:"components"`
-	Default    bool     `yaml:"default"`
+	Version    string     `yaml:"version"`
+	Suites     []string   `yaml:"suites"`
+	Components []string   `yaml:"components"`
+	Default    bool       `yaml:"default"`
+	Pro        string     `yaml:"pro"`
 }
 
 type yamlPackage struct {
@@ -428,6 +430,11 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		if len(details.Components) == 0 {
 			return nil, fmt.Errorf("%s: archive %q missing components field", fileName, archiveName)
 		}
+		switch details.Pro {
+		case "", "fips", "fips-updates":
+		default:
+			return nil, fmt.Errorf("%s: archive %q has invalid pro value: %q", fileName, archiveName, details.Pro)
+		}
 		if len(yamlVar.Archives) == 1 {
 			details.Default = true
 		} else if details.Default && release.DefaultArchive != "" {
@@ -441,6 +448,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Version:    details.Version,
 			Suites:     details.Suites,
 			Components: details.Components,
+			Pro:        details.Pro,
 		}
 	}
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -30,6 +30,7 @@ type Archive struct {
 	Suites     []string
 	Components []string
 	Pro        string
+	Priority   int
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -323,6 +324,7 @@ type yamlArchive struct {
 	Suites     []string   `yaml:"suites"`
 	Components []string   `yaml:"components"`
 	Pro        string     `yaml:"pro"`
+	Priority   int        `yaml:"priority"`
 }
 
 type yamlPackage struct {
@@ -435,6 +437,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Suites:     details.Suites,
 			Components: details.Components,
 			Pro:        details.Pro,
+			Priority:   details.Priority,
 		}
 	}
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -39,24 +39,6 @@ var setupTests = []setupTest{{
 	},
 	relerror: `chisel.yaml: no archives defined`,
 }, {
-	summary: "Multiple archives",
-	input: map[string]string{
-		"chisel.yaml": `
-			format: chisel-v1
-			archives: {one: {version: 1}, two: {version: two}}
-		`,
-	},
-	relerror: `chisel.yaml: multiple archives not yet supported`,
-}, {
-	summary: "Only ubuntu archives for now",
-	input: map[string]string{
-		"chisel.yaml": `
-			format: chisel-v1
-			archives: {other: {version: 1}}
-		`,
-	},
-	relerror: `chisel.yaml: only "ubuntu" archives are supported for now`,
-}, {
 	summary: "Enforce matching filename and package name",
 	input: map[string]string{
 		"slices/mydir/mypkg.yaml": `
@@ -713,6 +695,42 @@ var setupTests = []setupTest{{
 						},
 					},
 				},
+			},
+		},
+	},
+}, {
+	summary: "Multiple archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					default: true
+				bar:
+					version: 22.04
+					components: [universe]
+					suites: [jammy-updates]
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		DefaultArchive: "foo",
+
+		Archives: map[string]*setup.Archive{
+			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}},
+			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Archive: "foo",
+				Name:    "mypkg",
+				Path:    "slices/mydir/mypkg.yaml",
+				Slices:  map[string]*setup.Slice{},
 			},
 		},
 	},

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -64,7 +64,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -100,7 +100,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -154,7 +154,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -407,7 +407,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -614,7 +614,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -646,7 +646,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -679,7 +679,7 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -722,12 +722,49 @@ var setupTests = []setupTest{{
 		DefaultArchive: "foo",
 
 		Archives: map[string]*setup.Archive{
-			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}},
-			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}},
+			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""},
+			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}, ""},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "foo",
+				Name:    "mypkg",
+				Path:    "slices/mydir/mypkg.yaml",
+				Slices:  map[string]*setup.Slice{},
+			},
+		},
+	},
+}, {
+	summary: "Archive with pro property",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				ubuntu:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy, jammy-updates, jammy-security]
+					default: true
+				ubuntu-fips:
+					pro: fips
+					version: 22.04
+					components: [main]
+					suites: [jammy]
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		DefaultArchive: "ubuntu",
+
+		Archives: map[string]*setup.Archive{
+			"ubuntu":      {"ubuntu", "22.04", []string{"jammy", "jammy-updates", "jammy-security"}, []string{"main", "universe"}, ""},
+			"ubuntu-fips": {"ubuntu-fips", "22.04", []string{"jammy"}, []string{"main"}, "fips"},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices:  map[string]*setup.Slice{},

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -62,7 +62,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -95,7 +95,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -146,7 +146,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -396,7 +396,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -600,7 +600,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -629,7 +629,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -659,7 +659,7 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
+		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Name:    "mypkg",
@@ -698,8 +698,8 @@ var setupTests = []setupTest{{
 	},
 	release: &setup.Release{
 		Archives: map[string]*setup.Archive{
-			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""},
-			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}, ""},
+			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}, "", 0},
+			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}, "", 0},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
@@ -731,8 +731,8 @@ var setupTests = []setupTest{{
 	},
 	release: &setup.Release{
 		Archives: map[string]*setup.Archive{
-			"ubuntu":      {"ubuntu", "22.04", []string{"jammy", "jammy-updates", "jammy-security"}, []string{"main", "universe"}, ""},
-			"ubuntu-fips": {"ubuntu-fips", "22.04", []string{"jammy"}, []string{"main"}, "fips"},
+			"ubuntu":      {"ubuntu", "22.04", []string{"jammy", "jammy-updates", "jammy-security"}, []string{"main", "universe"}, "", 0},
+			"ubuntu-fips": {"ubuntu-fips", "22.04", []string{"jammy"}, []string{"main"}, "fips", 0},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -62,12 +62,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{},
@@ -98,12 +95,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -152,12 +146,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -405,12 +396,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -612,12 +600,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -644,12 +629,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -677,12 +659,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""}},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
@@ -708,7 +687,6 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy]
-					default: true
 				bar:
 					version: 22.04
 					components: [universe]
@@ -719,15 +697,12 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "foo",
-
 		Archives: map[string]*setup.Archive{
 			"foo": {"foo", "22.04", []string{"jammy"}, []string{"main", "universe"}, ""},
 			"bar": {"bar", "22.04", []string{"jammy-updates"}, []string{"universe"}, ""},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "foo",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices:  map[string]*setup.Slice{},
@@ -744,7 +719,6 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy, jammy-updates, jammy-security]
-					default: true
 				ubuntu-fips:
 					pro: fips
 					version: 22.04
@@ -756,15 +730,12 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu":      {"ubuntu", "22.04", []string{"jammy", "jammy-updates", "jammy-security"}, []string{"main", "universe"}, ""},
 			"ubuntu-fips": {"ubuntu-fips", "22.04", []string{"jammy"}, []string{"main"}, "fips"},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
 				Slices:  map[string]*setup.Slice{},


### PR DESCRIPTION
This PR adds support for FIPS repositories along with preparatory changes:
- Bump Go to 1.20 and `go mod tidy`. Some new code uses [`errors.Join`](https://pkg.go.dev/errors#Join).
- No longer limit the archives to a single archive named "ubuntu".
- Do not tie packages to individual archives. Instead, select the most recent version from all archives.
- Add support for archive priorities. If a package to be downloaded exists in both archive A and archive B and archive A has higher priority than archive B, the package is downloaded from archive A even if archive B has a newer version. If two or more archives have the same priority, the most recent version of the package in any of these archive is selected, if any. Otherwise, archives with lower priority are tried.
- Support parsing of archive credentials from configuration files in `/etc/apt/auth.conf.d/`. This is not enabled by default, see below.
- Support Pro archives by pro property in chisel.yaml. When a pro property is specified, it has to be either "fips" or "fips-updates". The repository URL is inferred from the value. Also, credentials for these URLs are searched (see above). If credentials are not found, the corresponding pro archive is silently disabled. Otherwise, all requests to the archive are sent with the credentials found.

Currently, fips and fips-updates exists only for focal for which we don't have chisel-releases yet. I've created a fork with reduced set of slices. You can try this implementation with it provided you have pro fips-updates credentials available on your machine.

```
% cd /path/to/chisel/sources
% git clone -b ubuntu-20.04 https://github.com/woky/chisel-releases
% cat auth.conf.d/90ubuntu-advantage
machine esm.ubuntu.com/fips-updates/ login bearer password [...REDACTED...]  # ubuntu-advantage-tools
% export CHISEL_AUTH_DIR=$PWD/auth.conf.d
% mkdir -p out
% ./chisel cut --release ./chisel-releases --root out openssl_bins
2023/05/05 09:47:56 Processing ../chisel-releases release...
2023/05/05 09:47:56 Selecting slices...
2023/05/05 09:47:56 Fetching ubuntu 20.04 focal suite details...
2023/05/05 09:47:57 Release date: Thu, 23 Apr 2020 17:33:17 UTC
2023/05/05 09:47:57 Fetching index for ubuntu 20.04 focal main component...
2023/05/05 09:47:57 Fetching index for ubuntu 20.04 focal universe component...
2023/05/05 09:47:57 Fetching ubuntu 20.04 focal-security suite details...
2023/05/05 09:47:58 Release date: Fri, 05 May 2023  6:19:24 UTC
2023/05/05 09:47:58 Fetching index for ubuntu 20.04 focal-security main component...
2023/05/05 09:47:58 Fetching index for ubuntu 20.04 focal-security universe component...
2023/05/05 09:47:58 Fetching ubuntu 20.04 focal-updates suite details...
2023/05/05 09:47:58 Release date: Fri, 05 May 2023  7:29:11 UTC
2023/05/05 09:47:58 Fetching index for ubuntu 20.04 focal-updates main component...
2023/05/05 09:47:58 Fetching index for ubuntu 20.04 focal-updates universe component...
2023/05/05 09:47:59 Fetching ubuntu-fips-updates 20.04 focal-updates suite details...
2023/05/05 09:47:59 Release date: Fri, 28 Apr 2023 11:20:11 UTC
2023/05/05 09:47:59 Fetching index for ubuntu-fips-updates 20.04 focal-updates main component...
2023/05/05 09:47:59 Fetching pool/main/g/glibc/libc6_2.31-0ubuntu9.9_amd64.deb...
2023/05/05 09:47:59 Fetching pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.fips.18_amd64.deb...
2023/05/05 09:48:00 Fetching pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.fips.18_amd64.deb...
2023/05/05 09:48:00 Extracting files from package "libc6"...
2023/05/05 09:48:03 Extracting files from package "libssl1.1"...
2023/05/05 09:48:05 Extracting files from package "openssl"...
```