### PR TITLE
Refactor setup_test.go

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -82,13 +82,20 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy", "jammy-security"}, []string{"main", "other"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy", "jammy-security"},
+				Components: []string{"main", "other"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
 				Name:    "mypkg",
 				Path:    "slices/mydir/mypkg.yaml",
-				Slices: map[string]*setup.Slice{},
+				Slices:  map[string]*setup.Slice{},
 			},
 		},
 	},
@@ -118,7 +125,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -172,7 +186,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -352,7 +373,7 @@ var setupTests = []setupTest{{
 						/path1: {copy: /other}
 		`,
 	},
-	relerror:  "slices mypkg1_myslice1 and mypkg1_myslice2 conflict on /path1",
+	relerror: "slices mypkg1_myslice1 and mypkg1_myslice2 conflict on /path1",
 }, {
 	summary: "Conflicting paths across packages",
 	input: map[string]string{
@@ -371,7 +392,7 @@ var setupTests = []setupTest{{
 						/path1:
 		`,
 	},
-	relerror:  "slices mypkg1_myslice1 and mypkg2_myslice1 conflict on /path1",
+	relerror: "slices mypkg1_myslice1 and mypkg2_myslice1 conflict on /path1",
 }, {
 	summary: "Directories must be suffixed with /",
 	input: map[string]string{
@@ -425,7 +446,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -468,7 +496,7 @@ var setupTests = []setupTest{{
 						/file/foob*r:
 		`,
 	},
-	relerror:  `slices mypkg1_myslice and mypkg2_myslice conflict on /file/f\*obar and /file/foob\*r`,
+	relerror: `slices mypkg1_myslice and mypkg2_myslice conflict on /file/f\*obar and /file/foob\*r`,
 }, {
 	summary: "Conflicting globs and plain copies",
 	input: map[string]string{
@@ -487,7 +515,7 @@ var setupTests = []setupTest{{
 						/file/foob*r:
 		`,
 	},
-	relerror:  `slices mypkg1_myslice and mypkg2_myslice conflict on /file/foobar and /file/foob\*r`,
+	relerror: `slices mypkg1_myslice and mypkg2_myslice conflict on /file/foobar and /file/foob\*r`,
 }, {
 	summary: "Conflicting matching globs",
 	input: map[string]string{
@@ -506,7 +534,7 @@ var setupTests = []setupTest{{
 						/file/foob*r:
 		`,
 	},
-	relerror:  `slices mypkg1_myslice and mypkg2_myslice conflict on /file/foob\*r`,
+	relerror: `slices mypkg1_myslice and mypkg2_myslice conflict on /file/foob\*r`,
 }, {
 	summary: "Conflicting globs in same package is okay",
 	input: map[string]string{
@@ -534,7 +562,7 @@ var setupTests = []setupTest{{
 						/file/foob*r: {text: foo}
 		`,
 	},
-	relerror:  `slice mypkg_myslice path /file/foob\*r has invalid wildcard options`,
+	relerror: `slice mypkg_myslice path /file/foob\*r has invalid wildcard options`,
 }, {
 	summary: "Until is an okay option for globs",
 	input: map[string]string{
@@ -557,7 +585,7 @@ var setupTests = []setupTest{{
 						/path/: {mutable: true}
 		`,
 	},
-	relerror:  `slice mypkg_myslice mutable is not a regular file: /path/`,
+	relerror: `slice mypkg_myslice mutable is not a regular file: /path/`,
 }, {
 	summary: "Mutable does not work for directory making",
 	input: map[string]string{
@@ -569,7 +597,7 @@ var setupTests = []setupTest{{
 						/path/: {make: true, mutable: true}
 		`,
 	},
-	relerror:  `slice mypkg_myslice mutable is not a regular file: /path/`,
+	relerror: `slice mypkg_myslice mutable is not a regular file: /path/`,
 }, {
 	summary: "Mutable does not work for symlinks",
 	input: map[string]string{
@@ -581,7 +609,7 @@ var setupTests = []setupTest{{
 						/path: {symlink: /other, mutable: true}
 		`,
 	},
-	relerror:  `slice mypkg_myslice mutable is not a regular file: /path`,
+	relerror: `slice mypkg_myslice mutable is not a regular file: /path`,
 }, {
 	summary: "Until checks its value for validity",
 	input: map[string]string{
@@ -593,7 +621,7 @@ var setupTests = []setupTest{{
 						/path: {until: foo}
 		`,
 	},
-	relerror:  `slice mypkg_myslice has invalid 'until' for path /path: "foo"`,
+	relerror: `slice mypkg_myslice has invalid 'until' for path /path: "foo"`,
 }, {
 	summary: "Arch checks its value for validity",
 	input: map[string]string{
@@ -605,7 +633,7 @@ var setupTests = []setupTest{{
 						/path: {arch: foo}
 		`,
 	},
-	relerror:  `slice mypkg_myslice has invalid 'arch' for path /path: "foo"`,
+	relerror: `slice mypkg_myslice has invalid 'arch' for path /path: "foo"`,
 }, {
 	summary: "Arch checks its value for validity",
 	input: map[string]string{
@@ -617,7 +645,7 @@ var setupTests = []setupTest{{
 						/path: {arch: [i386, foo]}
 		`,
 	},
-	relerror:  `slice mypkg_myslice has invalid 'arch' for path /path: "foo"`,
+	relerror: `slice mypkg_myslice has invalid 'arch' for path /path: "foo"`,
 }, {
 	summary: "Single architecture selection",
 	input: map[string]string{
@@ -632,7 +660,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -664,7 +699,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",
@@ -697,7 +739,14 @@ var setupTests = []setupTest{{
 	release: &setup.Release{
 		DefaultArchive: "ubuntu",
 
-		Archives: map[string]*setup.Archive{"ubuntu": {"ubuntu", "22.04", []string{"jammy"}, []string{"main", "universe"}}},
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
 				Archive: "ubuntu",


### PR DESCRIPTION
Archive structure is going to gain optional fields in followup commits. 
Change the structure definitions in setup_test.go to field:value format so
that new optional fields won't require extending the definition with zero
values.

Also format it with go fmt.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----