### PR TITLE
Drop single "ubuntu" archive restriction

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -29,9 +29,6 @@ type Options struct {
 }
 
 func Open(options *Options) (Archive, error) {
-	if options.Label != "ubuntu" {
-		return nil, fmt.Errorf("non-ubuntu archives are not supported yet")
-	}
 	var err error
 	if options.Arch == "" {
 		options.Arch, err = deb.InferArch()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -413,15 +413,8 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 	if len(yamlVar.Archives) == 0 {
 		return nil, fmt.Errorf("%s: no archives defined", fileName)
 	}
-	if len(yamlVar.Archives) > 1 {
-		return nil, fmt.Errorf("%s: multiple archives not yet supported", fileName)
-	}
 
 	for archiveName, details := range yamlVar.Archives {
-		const ubuntuArchive = "ubuntu"
-		if archiveName != ubuntuArchive {
-			return nil, fmt.Errorf("%s: only %q archives are supported for now", fileName, ubuntuArchive)
-		}
 		if details.Version == "" {
 			return nil, fmt.Errorf("%s: archive %q missing version field", fileName, archiveName)
 		}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -39,24 +39,6 @@ var setupTests = []setupTest{{
 	},
 	relerror: `chisel.yaml: no archives defined`,
 }, {
-	summary: "Multiple archives",
-	input: map[string]string{
-		"chisel.yaml": `
-			format: chisel-v1
-			archives: {one: {version: 1}, two: {version: two}}
-		`,
-	},
-	relerror: `chisel.yaml: multiple archives not yet supported`,
-}, {
-	summary: "Only ubuntu archives for now",
-	input: map[string]string{
-		"chisel.yaml": `
-			format: chisel-v1
-			archives: {other: {version: 1}}
-		`,
-	},
-	relerror: `chisel.yaml: only "ubuntu" archives are supported for now`,
-}, {
 	summary: "Enforce matching filename and package name",
 	input: map[string]string{
 		"slices/mydir/mypkg.yaml": `
@@ -713,6 +695,52 @@ var setupTests = []setupTest{{
 						},
 					},
 				},
+			},
+		},
+	},
+}, {
+	summary: "Multiple archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					default: true
+				bar:
+					version: 22.04
+					components: [universe]
+					suites: [jammy-updates]
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		DefaultArchive: "foo",
+
+		Archives: map[string]*setup.Archive{
+			"foo": {
+				Name:       "foo",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main", "universe"},
+			},
+			"bar": {
+				Name:       "bar",
+				Version:    "22.04",
+				Suites:     []string{"jammy-updates"},
+				Components: []string{"universe"},
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Archive: "foo",
+				Name:    "mypkg",
+				Path:    "slices/mydir/mypkg.yaml",
+				Slices:  map[string]*setup.Slice{},
 			},
 		},
 	},


### PR DESCRIPTION
Currently, we allow only a single archive named "ubuntu" to be defined in
chisel.yaml. Drop this restriction in preparation for the support of 
multiple archives.

When more than one archive is defined, one of them has to be specified as
the default one. When a slice definition file doesn't specify which archive
the sliced package belongs to, it is assumed it belongs to the default
archive.

This commit, in effect, doesn't change current behavior because we don't 
allow archives to define their URLs. It's only preparation for future 
commits that will add support for different types of archives.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----