### PR TITLE
Add support for Pro FIPS archives

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -91,6 +91,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Suites:     archiveInfo.Suites,
 			Components: archiveInfo.Components,
 			CacheDir:   cache.DefaultDir("chisel"),
+			Priority:   archiveInfo.Priority,
 		})
 		if err != nil {
 			return err

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -92,11 +92,19 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Components: archiveInfo.Components,
 			CacheDir:   cache.DefaultDir("chisel"),
 			Priority:   archiveInfo.Priority,
+			Pro:        archiveInfo.Pro,
 		})
 		if err != nil {
-			return err
+			if err != archive.ErrCredentialsNotFound {
+				return err
+			}
+		} else {
+			archives[archiveName] = openArchive
 		}
-		archives[archiveName] = openArchive
+	}
+
+	if len(archives) == 0 {
+		return fmt.Errorf("no valid archives (%d skipped)", len(release.Archives))
 	}
 
 	return slicer.Run(&slicer.RunOptions{

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -34,6 +34,7 @@ type Options struct {
 	Suites     []string
 	Components []string
 	CacheDir   string
+	Priority   int
 }
 
 func Open(options *Options) (Archive, error) {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -34,7 +34,7 @@ type Options struct {
 	Suites     []string
 	Components []string
 	CacheDir   string
-	Priority   int
+	Priority   int32
 }
 
 func Open(options *Options) (Archive, error) {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -332,6 +332,39 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 	c.Assert(err, ErrorMatches, `.*\bno Ubuntu section`)
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+	}
+
+	archive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1 := archive.Info("mypkg1")
+	c.Assert(info1, NotNil)
+	c.Assert(info1.Name(), Equals, "mypkg1")
+	c.Assert(info1.Version(), Equals, "1.1")
+	c.Assert(info1.Arch(), Equals, "amd64")
+	c.Assert(info1.SHA256(), Equals, "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05")
+
+	info3 := archive.Info("mypkg3")
+	c.Assert(info3, NotNil)
+	c.Assert(info3.Name(), Equals, "mypkg3")
+	c.Assert(info3.Version(), Equals, "1.3")
+	c.Assert(info3.Arch(), Equals, "amd64")
+	c.Assert(info3.SHA256(), Equals, "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa")
+
+	info99 := archive.Info("mypkg99")
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -29,6 +29,7 @@ type Archive struct {
 	Version    string
 	Suites     []string
 	Components []string
+	Priority   int
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -321,6 +322,7 @@ type yamlArchive struct {
 	Version    string   `yaml:"version"`
 	Suites     []string `yaml:"suites"`
 	Components []string `yaml:"components"`
+	Priority   int      `yaml:"priority"`
 }
 
 type yamlPackage struct {
@@ -427,6 +429,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Version:    details.Version,
 			Suites:     details.Suites,
 			Components: details.Components,
+			Priority:   details.Priority,
 		}
 	}
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -30,6 +30,7 @@ type Archive struct {
 	Suites     []string
 	Components []string
 	Priority   int32
+	Pro        string
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -323,6 +324,7 @@ type yamlArchive struct {
 	Suites     []string `yaml:"suites"`
 	Components []string `yaml:"components"`
 	Priority   int32    `yaml:"priority"`
+	Pro        string   `yaml:"pro"`
 }
 
 type yamlPackage struct {
@@ -430,6 +432,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Suites:     details.Suites,
 			Components: details.Components,
 			Priority:   details.Priority,
+			Pro:        details.Pro,
 		}
 	}
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -29,7 +29,7 @@ type Archive struct {
 	Version    string
 	Suites     []string
 	Components []string
-	Priority   int
+	Priority   int32
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -322,7 +322,7 @@ type yamlArchive struct {
 	Version    string   `yaml:"version"`
 	Suites     []string `yaml:"suites"`
 	Components []string `yaml:"components"`
-	Priority   int      `yaml:"priority"`
+	Priority   int32    `yaml:"priority"`
 }
 
 type yamlPackage struct {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -766,6 +766,30 @@ var setupTests = []setupTest{{
 			},
 		},
 	},
+}, {
+	summary: "Maximum priority",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				upper-limit:
+					version: 1
+					suites: [main]
+					components: [main]
+					priority: 2147483647
+				lower-limit:
+					version: 1
+					suites: [main]
+					components: [main]
+					priority: -2147483648
+				over-limit:
+					version: 1
+					suites: [main]
+					components: [main]
+					priority: 2147483648
+		`,
+	},
+	relerror: "(?s).*\\bcannot unmarshal !!int `2147483648` into int32\\b.*",
 }}
 
 const defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -790,6 +790,50 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: "(?s).*\\bcannot unmarshal !!int `2147483648` into int32\\b.*",
+}, {
+	summary: "Pro property",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				ubuntu:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy, jammy-updates, jammy-security]
+				ubuntu-fips:
+					pro: fips
+					version: 22.04
+					components: [main]
+					suites: [jammy]
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy", "jammy-updates", "jammy-security"},
+				Components: []string{"main", "universe"},
+			},
+			"ubuntu-fips": {
+				Name:       "ubuntu-fips",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main"},
+				Pro:        "fips",
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
+			},
+		},
+	},
 }}
 
 const defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -60,8 +60,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -72,10 +70,9 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
-				Slices:  map[string]*setup.Slice{},
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
 			},
 		},
 	},
@@ -103,8 +100,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -115,9 +110,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -164,8 +158,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -176,9 +168,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -424,8 +415,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -436,9 +425,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -638,8 +626,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -650,9 +636,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -677,8 +662,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -689,9 +672,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -717,8 +699,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -729,9 +709,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -755,7 +734,6 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy]
-					default: true
 				bar:
 					version: 22.04
 					components: [universe]
@@ -766,8 +744,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "foo",
-
 		Archives: map[string]*setup.Archive{
 			"foo": {
 				Name:       "foo",
@@ -784,10 +760,9 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "foo",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
-				Slices:  map[string]*setup.Slice{},
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
 			},
 		},
 	},

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -72,8 +72,8 @@ func Run(options *RunOptions) error {
 	}
 
 	// Archives are ordered in descending order by priority. The
-	// default priority is 0 and the maximum allowed priority is
-	// the upper limit of int.
+	// default priority is 0 and the range of allowed priorities
+	// is the same as the range of the int32 data type.
 	//
 	// If a package to be downloaded exists in archive A and
 	// archive B, and archive A has higher priority than archive
@@ -111,7 +111,7 @@ func Run(options *RunOptions) error {
 		if extractPackage == nil {
 			var selectedVersion string
 			var selectedArchive archive.Archive
-			currentPrio := math.MaxInt
+			var currentPrio int32 = math.MaxInt32
 			for _, currentArchive := range orderedArchives {
 				if prio := currentArchive.Options().Priority; prio < currentPrio {
 					if selectedVersion != "" {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -59,7 +59,6 @@ func Run(options *RunOptions) error {
 		syscall.Umask(oldUmask)
 	}()
 
-	release := options.Selection.Release
 	targetDir := filepath.Clean(options.TargetDir)
 	targetDirAbs := targetDir
 	if !filepath.IsAbs(targetDirAbs) {
@@ -74,15 +73,23 @@ func Run(options *RunOptions) error {
 	for _, slice := range options.Selection.Slices {
 		extractPackage := extract[slice.Package]
 		if extractPackage == nil {
-			archiveName := release.Packages[slice.Package].Archive
-			archive := options.Archives[archiveName]
-			if archive == nil {
-				return fmt.Errorf("archive %q not defined", archiveName)
+			var selectedVersion string
+			var selectedArchive archive.Archive
+			for _, currentArchive := range options.Archives {
+				pkgInfo := currentArchive.Info(slice.Package)
+				if pkgInfo == nil {
+					continue
+				}
+				currentVersion := pkgInfo.Version()
+				if selectedVersion == "" || deb.CompareVersions(selectedVersion, currentVersion) < 0 {
+					selectedVersion = currentVersion
+					selectedArchive = currentArchive
+				}
 			}
-			if !archive.Exists(slice.Package) {
+			if selectedVersion == "" {
 				return fmt.Errorf("slice package %q missing from archive", slice.Package)
 			}
-			archives[slice.Package] = archive
+			archives[slice.Package] = selectedArchive
 			extractPackage = make(map[string][]deb.ExtractInfo)
 			extract[slice.Package] = extractPackage
 		}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -508,7 +508,6 @@ var slicerTests = []slicerTest{{
 				foo:
 					version: 22.04
 					components: [main, universe]
-					default: true
 				bar:
 					version: 22.04
 					components: [main]
@@ -562,7 +561,6 @@ var slicerTests = []slicerTest{{
 					version: 1
 					suites: [main]
 					components: [main, universe]
-					default: true
 				hadrons:
 					version: 1
 					suites: [main]
@@ -577,7 +575,6 @@ var slicerTests = []slicerTest{{
 		`,
 		"slices/mydir/proton.yaml": `
 			package: proton
-			archive: hadrons
 			slices:
 				mass:
 					contents:
@@ -597,6 +594,97 @@ var slicerTests = []slicerTest{{
 		"/usr/share/doc/":                   "dir 0755",
 		"/usr/share/doc/electron/":          "dir 0755",
 		"/usr/share/doc/electron/copyright": "file 0644 empty",
+	},
+}, {
+	summary: "Can pick latest packages from multiple archives",
+	pkgs: map[string]map[string]testPackage{
+		"vertebrates": {
+			"cheetah": testPackage{
+				info: map[string]string{
+					"Version": "109.4",
+				},
+				content: testutil.MustMakeDeb([]testutil.TarEntry{
+					Dir(0755, "./"),
+					Dir(0755, "./speed/"),
+					Reg(0644, "./speed/cheetah", "109.4 km/h\n"),
+				}),
+			},
+			"ostrich": testPackage{
+				info: map[string]string{
+					"Version": "100.0",
+				},
+				content: testutil.MustMakeDeb([]testutil.TarEntry{
+					Dir(0755, "./"),
+					Dir(0755, "./speed/"),
+					Reg(0644, "./speed/ostrich", "100.0 km/h\n"),
+				}),
+			},
+		},
+		"mammals": {
+			"cheetah": testPackage{
+				info: map[string]string{
+					"Version": "120.7",
+				},
+				content: testutil.MustMakeDeb([]testutil.TarEntry{
+					Dir(0755, "./"),
+					Dir(0755, "./speed/"),
+					Reg(0644, "./speed/cheetah", "120.7 km/h\n"),
+				}),
+			},
+		},
+		"birds": {
+			"ostrich": testPackage{
+				info: map[string]string{
+					"Version": "90.0",
+				},
+				content: testutil.MustMakeDeb([]testutil.TarEntry{
+					Dir(0755, "./"),
+					Dir(0755, "./speed/"),
+					Reg(0644, "./speed/ostrich", "90.0 km/h\n"),
+				}),
+			},
+		},
+	},
+	slices: []setup.SliceKey{
+		{"cheetah", "speed"},
+		{"ostrich", "speed"},
+	},
+	release: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				vertebrates:
+					version: 1
+					suites: [main]
+					components: [main, universe]
+				mammals:
+					version: 1
+					suites: [main]
+					components: [main]
+				birds:
+					version: 1
+					suites: [main]
+					components: [main]
+		`,
+		"slices/mydir/cheetah.yaml": `
+			package: cheetah
+			slices:
+				speed:
+					contents:
+						/speed/cheetah:
+		`,
+		"slices/mydir/ostrich.yaml": `
+			package: ostrich
+			slices:
+				speed:
+					contents:
+						/speed/ostrich:
+		`,
+	},
+	result: map[string]string{
+		"/speed/":        "dir 0755",
+		"/speed/cheetah": "file 0644 e98b0879",
+		"/speed/ostrich": "file 0644 c8fa2806",
 	},
 }}
 

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -948,6 +948,7 @@ func (s *S) TestRun(c *C) {
 					Suites:     setupArchive.Suites,
 					Components: setupArchive.Components,
 					Priority:   setupArchive.Priority,
+					Pro:        setupArchive.Pro,
 					Arch:       test.arch,
 				},
 				pkgs: archivePkgs,


### PR DESCRIPTION
Support Pro archives by a pro property in chisel.yaml. When the pro 
property is specified, it has to be either "fips" or "fips-updates". The 
repository URL is inferred from the value. Also, credentials for these URLs
are searched. If credentials are not found, the corresponding pro archive
is silently disabled. Otherwise, all requests to the archive are sent with
the credentials found.

This PR depends on #60 and #59 

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----