### PR TITLE
Allow same globs in multiple slices

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -38,8 +38,10 @@ func checkExtractOptions(options *ExtractOptions) error {
 	for extractPath, extractInfos := range options.Extract {
 		isGlob := strings.ContainsAny(extractPath, "*?")
 		if isGlob {
-			if len(extractInfos) != 1 || extractInfos[0].Path != extractPath || extractInfos[0].Mode != 0 {
-				return fmt.Errorf("when using wildcards source and target paths must match: %s", extractPath)
+			for _, info := range extractInfos {
+				if info.Path != extractPath || info.Mode != 0 {
+					return fmt.Errorf("when using wildcards source and target paths must match: %s", extractPath)
+				}
 			}
 		}
 	}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -170,7 +170,7 @@ var extractTests = []extractTest{{
 	},
 	error: `cannot extract .*: when using wildcards source and target paths must match: /etc/d\*\*`,
 }, {
-	summary: "Globbing must also have a single target",
+	summary: "Two slices can declare the same glob",
 	pkgdata: testutil.PackageData["base-files"],
 	options: deb.ExtractOptions{
 		Extract: map[string][]deb.ExtractInfo{
@@ -181,7 +181,25 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract .*: when using wildcards source and target paths must match: /etc/d\*\*`,
+	result: map[string]string{
+		"/etc/": "dir 0755",
+		"/etc/debian_version": "file 0644 cce26cfe",
+		"/etc/default/": "dir 0755",
+		"/etc/dpkg/": "dir 0755",
+		"/etc/dpkg/origins/": "dir 0755",
+		"/etc/dpkg/origins/debian": "file 0644 50f35af8",
+		"/etc/dpkg/origins/ubuntu": "file 0644 d2537b95",
+	},
+	globbed: map[string][]string{
+		"/etc/d**": []string{
+			"/etc/debian_version",
+			"/etc/default/",
+			"/etc/dpkg/",
+			"/etc/dpkg/origins/",
+			"/etc/dpkg/origins/debian",
+			"/etc/dpkg/origins/ubuntu",
+		},
+	},
 }, {
 	summary: "Globbing cannot change modes",
 	pkgdata: testutil.PackageData["base-files"],


### PR DESCRIPTION
There's no reason why the following slices shouldn't be accepted when
the globs are identical:

    package: openjdk-8-jre-headless
    slices:
      abc:
        contents:
          /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnpt.so:
      bcd:
        contents:
          /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnpt.so:

Drop this restriction.


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----