### PR TITLE
archive: Add Info() method

### DIFF
--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -332,6 +332,39 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 	c.Assert(err, ErrorMatches, `.*\bno Ubuntu section`)
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+	}
+
+	archive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1 := archive.Info("mypkg1")
+	c.Assert(info1, NotNil)
+	c.Assert(info1.Name(), Equals, "mypkg1")
+	c.Assert(info1.Version(), Equals, "1.1")
+	c.Assert(info1.Arch(), Equals, "amd64")
+	c.Assert(info1.SHA256(), Equals, "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05")
+
+	info3 := archive.Info("mypkg3")
+	c.Assert(info3, NotNil)
+	c.Assert(info3.Name(), Equals, "mypkg3")
+	c.Assert(info3.Version(), Equals, "1.3")
+	c.Assert(info3.Arch(), Equals, "amd64")
+	c.Assert(info3.SHA256(), Equals, "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa")
+
+	info99 := archive.Info("mypkg99")
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
At some point we will need to get information about (deb) packages from
(Go) packages other than archive, namely from the slicer package.
For instance:
- Package entries in Chisel DB will include version, digest and
  architecture.
- Multi-archive package selection will need to know versions of a
  package in all configured archives.

Add Info() method to the Archive interface that returns a new
PackageInfo interface that contains accessors for the underlying
control.Section of the package. Currently these accessors are Name(),
Version(), Arch() and SHA256() methods.

The reason to introduce PackageInfo interface instead of returing
control.Section directly is keep the archive abstraction and not leak
implementation details.