### PR TITLE
db: Add Chisel DB v0.1 skeleton

### DIFF
--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -332,6 +332,39 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 	c.Assert(err, ErrorMatches, `.*\bno Ubuntu section`)
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+	}
+
+	archive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1 := archive.Info("mypkg1")
+	c.Assert(info1, NotNil)
+	c.Assert(info1.Name(), Equals, "mypkg1")
+	c.Assert(info1.Version(), Equals, "1.1")
+	c.Assert(info1.Arch(), Equals, "amd64")
+	c.Assert(info1.SHA256(), Equals, "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05")
+
+	info3 := archive.Info("mypkg3")
+	c.Assert(info3, NotNil)
+	c.Assert(info3.Name(), Equals, "mypkg3")
+	c.Assert(info3.Version(), Equals, "1.3")
+	c.Assert(info3.Arch(), Equals, "amd64")
+	c.Assert(info3.SHA256(), Equals, "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa")
+
+	info99 := archive.Info("mypkg99")
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/chisel/internal/jsonwall"
+	"github.com/klauspost/compress/zstd"
+)
+
+const schema = "0.1"
+
+// New creates a new Chisel DB writer with the proper schema.
+func New() *jsonwall.DBWriter {
+	options := jsonwall.DBWriterOptions{Schema: schema}
+	return jsonwall.NewDBWriter(&options)
+}
+
+func getDBPath(root string) string {
+	return filepath.Join(root, ".chisel.db")
+}
+
+// Save uses the provided writer dbw to write the Chisel DB into the standard
+// path under the provided root directory.
+func Save(dbw *jsonwall.DBWriter, root string) (err error) {
+	dbPath := getDBPath(root)
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot save state to %q: %w", dbPath, err)
+		}
+	}()
+	f, err := os.OpenFile(dbPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	// chmod the existing file
+	if err = f.Chmod(0644); err != nil {
+		return
+	}
+	zw, err := zstd.NewWriter(f)
+	if err != nil {
+		return
+	}
+	if _, err = dbw.WriteTo(zw); err != nil {
+		return
+	}
+	return zw.Close()
+}
+
+// Load reads a Chisel DB from the standard path under the provided root
+// directory. If the Chisel DB doesn't exist, the returned error satisfies
+// errors.Is(err, fs.ErrNotExist))
+func Load(root string) (db *jsonwall.DB, err error) {
+	dbPath := getDBPath(root)
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot load state from %q: %w", dbPath, err)
+		}
+	}()
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		return
+	}
+	defer zr.Close()
+	db, err = jsonwall.ReadDB(zr)
+	if err != nil {
+		return nil, err
+	}
+	if s := db.Schema(); s != schema {
+		return nil, fmt.Errorf("invalid schema %#v", s)
+	}
+	return
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,74 @@
+package db_test
+
+import (
+	"sort"
+
+	"github.com/canonical/chisel/internal/db"
+	. "gopkg.in/check.v1"
+)
+
+type testEntry struct {
+	S string          `json:"s,omitempty"`
+	I int64           `json:"i,omitempty"`
+	L []string        `json:"l,omitempty"`
+	M map[string]bool `json:"m,omitempty"`
+}
+
+var saveLoadTestCase = []testEntry{
+	{"", 0, nil, nil},
+	{"hello", -1, nil, nil},
+	{"", 0, nil, nil},
+	{"", 100, []string{"a", "b"}, nil},
+	{"", 0, nil, map[string]bool{"a": true, "b": false}},
+	{"abc", 123, []string{"foo", "bar"}, nil},
+}
+
+func (s *S) TestSaveLoadRoundTrip(c *C) {
+	// To compare expected and obtained entries we first wrap the original
+	// entries in wrappers with increasing K. When we read the wrappers back
+	// they may be in different order because jsonwall sorts them serialized
+	// as JSON. So we sort them by K to compare them in the original order.
+
+	type wrapper struct {
+		// test values
+		testEntry
+		// sort key for comparison
+		K int `json:"key"`
+	}
+
+	// wrap the entries with increasing K
+	expected := make([]wrapper, len(saveLoadTestCase))
+	for i, entry := range saveLoadTestCase {
+		expected[i] = wrapper{entry, i}
+	}
+
+	workDir := c.MkDir()
+	dbw := db.New()
+	for _, entry := range expected {
+		err := dbw.Add(entry)
+		c.Assert(err, IsNil)
+	}
+	err := db.Save(dbw, workDir)
+	c.Assert(err, IsNil)
+
+	dbr, err := db.Load(workDir)
+	c.Assert(err, IsNil)
+	c.Assert(dbr.Schema(), Equals, db.Schema)
+
+	iter, err := dbr.Iterate(nil)
+	c.Assert(err, IsNil)
+
+	obtained := make([]wrapper, 0, len(expected))
+	for iter.Next() {
+		var wrapped wrapper
+		err := iter.Get(&wrapped)
+		c.Assert(err, IsNil)
+		obtained = append(obtained, wrapped)
+	}
+
+	// sort the entries by K to get the original order
+	sort.Slice(obtained, func(i, j int) bool {
+		return obtained[i].K < obtained[j].K
+	})
+	c.Assert(obtained, DeepEquals, expected)
+}

--- a/internal/db/export_test.go
+++ b/internal/db/export_test.go
@@ -1,0 +1,3 @@
+package db
+
+var Schema = schema

--- a/internal/db/suite_test.go
+++ b/internal/db/suite_test.go
@@ -1,0 +1,15 @@
+package db_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct{}
+
+var _ = Suite(&S{})

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -245,6 +245,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 		}
 
 		var pathReader io.Reader = tarReader
+		origMode := tarHeader.Mode
 		for _, extractInfo := range extractInfos {
 			if contentIsCached {
 				pathReader = bytes.NewReader(contentCache)
@@ -258,6 +259,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			if err := createParents(targetPath); err != nil {
 				return err
 			}
+			tarHeader.Mode = origMode
 			if extractInfo.Mode != 0 {
 				tarHeader.Mode = int64(extractInfo.Mode)
 			}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -413,6 +413,32 @@ var extractTests = []extractTest{{
 		"/a/b/c/":  "dir 0706",
 		"/a/b/c/d": "file 0601 empty",
 	},
+}, {
+	summary: "Copies with different permissions",
+	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
+		Dir(0701, "./a/"),
+		Reg(0601, "./b", ""),
+	}),
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/a/": []deb.ExtractInfo{
+				{Path: "/b/"},
+				{Path: "/c/", Mode: 0702},
+				{Path: "/d/", Mode: 01777},
+				{Path: "/e/"},
+				{Path: "/f/", Mode: 0723},
+				{Path: "/g/"},
+			},
+		},
+	},
+	result: map[string]string{
+		"/b/": "dir 0701",
+		"/c/": "dir 0702",
+		"/d/": "dir 01777",
+		"/e/": "dir 0701",
+		"/f/": "dir 0723",
+		"/g/": "dir 0701",
+	},
 }}
 
 func (s *S) TestExtract(c *C) {

--- a/internal/fsutil/path.go
+++ b/internal/fsutil/path.go
@@ -1,0 +1,66 @@
+package fsutil
+
+import (
+	"path/filepath"
+)
+
+// isDirPath returns whether the path refers to a directory.
+// The path refers to a directory when it ends with "/", "/." or "/..", or when
+// it equals "." or "..".
+func isDirPath(path string) bool {
+	i := len(path) - 1
+	if i < 0 {
+		return true
+	}
+	if path[i] == '.' {
+		i--
+		if i < 0 {
+			return true
+		}
+		if path[i] == '.' {
+			i--
+			if i < 0 {
+				return true
+			}
+		}
+	}
+	if path[i] == '/' {
+		return true
+	}
+	return false
+}
+
+// Debian package tarballs present paths slightly differently to what we would
+// normally classify as clean paths. While a traditional clean file path is identical
+// to a clean deb package file path, the deb package directory path always ends
+// with a slash. Although the change only affects directory paths, the implication
+// is that a directory path without a slash is interpreted as a file path. For this
+// reason, we need to be very careful and handle both file and directory paths using
+// a new set of functions. We call this new path type a Slashed Path. A slashed path
+// allows us to identify a file or directory simply using lexical analysis.
+
+// SlashedPathClean takes a file or slashed directory path as input, and produces
+// the shortest equivalent as output. An input path ending without a slash will be
+// interpreted as a file path. Directory paths should always end with a slash.
+// These functions exists because we work with slash terminated directory paths
+// that come from deb package tarballs but standard library path functions
+// treat slash terminated paths as unclean.
+func SlashedPathClean(path string) string {
+	clean := filepath.Clean(path)
+	if clean != "/" && isDirPath(path) {
+		clean += "/"
+	}
+	return clean
+}
+
+// SlashedPathDir takes a file or slashed directory path as input, cleans the
+// path and returns the parent directory. An input path ending without a slash
+// will be interpreted as a file path. Directory paths should always end with a slash.
+// Clean is like filepath.Clean() but trailing slash is kept.
+func SlashedPathDir(path string) string {
+	parent := filepath.Dir(filepath.Clean(path))
+	if parent != "/" {
+		parent += "/"
+	}
+	return parent
+}

--- a/internal/fsutil/path_test.go
+++ b/internal/fsutil/path_test.go
@@ -1,0 +1,54 @@
+package fsutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/fsutil"
+)
+
+var cleanAndDirTestCases = []struct {
+	inputPath   string
+	resultClean string
+	resultDir   string
+}{
+	{"/a/b/c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/c//", "/a/b/c/", "/a/b/"},
+	{"/a/b//c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/.", "/a/b/c/", "/a/b/"},
+	{"/a/b/c/.///.", "/a/b/c/", "/a/b/"},
+	{"/a/b/./c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/.///./c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/..", "/a/b/", "/a/"},
+	{"/a/b/c/..///./", "/a/b/", "/a/"},
+	{"/a/b/c/../.", "/a/b/", "/a/"},
+	{"/a/b/../c/", "/a/c/", "/a/"},
+	{"/a/b/..///./c", "/a/c", "/a/"},
+	{"a/b/./c", "a/b/c", "a/b/"},
+	{"./a/b/./c", "a/b/c", "a/b/"},
+	{"/", "/", "/"},
+	{"///", "/", "/"},
+	{"///.///", "/", "/"},
+	{"/././.", "/", "/"},
+	{".", "./", "./"},
+	{".///", "./", "./"},
+	{"..", "../", "./"},
+	{"..///.", "../", "./"},
+	{"../../..", "../../../", "../../"},
+	{"..///.///../..", "../../../", "../../"},
+	{"", "./", "./"},
+}
+
+func (s *S) TestSlashedPathClean(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultClean)
+		c.Assert(fsutil.SlashedPathClean(t.inputPath), Equals, t.resultClean)
+	}
+}
+
+func (s *S) TestSlashedPathDir(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultDir)
+		c.Assert(fsutil.SlashedPathDir(t.inputPath), Equals, t.resultDir)
+	}
+}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -109,14 +109,13 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := fsutil.SlashedPathDir(targetPath)
-				if targetDir == "" || targetDir == "/" {
-					continue
+				parent := fsutil.SlashedPathDir(targetPath)
+				for ; parent != "/"; parent = fsutil.SlashedPathDir(parent) {
+					extractPackage[parent] = append(extractPackage[parent], deb.ExtractInfo{
+						Path:     parent,
+						Optional: true,
+					})
 				}
-				extractPackage[targetDir] = append(extractPackage[targetDir], deb.ExtractInfo{
-					Path:     targetDir,
-					Optional: true,
-				})
 			}
 		}
 		if !hasCopyright {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -32,25 +32,21 @@ func Run(options *RunOptions) error {
 
 	knownPaths["/"] = true
 
+	// addKnownPath path adds path and all its directory parent paths into
+	// knownPaths set.
 	addKnownPath := func(path string) {
 		if path[0] != '/' {
 			panic("bug: tried to add relative path to known paths")
 		}
-		cleanPath := filepath.Clean(path)
-		slashPath := cleanPath
-		if path[len(path)-1] == '/' && cleanPath != "/" {
-			slashPath += "/"
-		}
+		path = fsutil.SlashedPathClean(path)
 		for {
-			if _, ok := knownPaths[slashPath]; ok {
+			if _, ok := knownPaths[path]; ok {
 				break
 			}
-			knownPaths[slashPath] = true
-			cleanPath = filepath.Dir(cleanPath)
-			if cleanPath == "/" {
+			knownPaths[path] = true
+			if path = fsutil.SlashedPathDir(path); path == "/" {
 				break
 			}
-			slashPath = cleanPath + "/"
 		}
 	}
 
@@ -113,7 +109,7 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := filepath.Dir(strings.TrimRight(targetPath, "/")) + "/"
+				targetDir := fsutil.SlashedPathDir(targetPath)
 				if targetDir == "" || targetDir == "/" {
 					continue
 				}


### PR DESCRIPTION
This commit adds the skeleton db package that will grow into the full
Chisel DB implementation with forthcoming commits. The package contains
only New(), Save(), and Load() functions for creating, writing, and
reading the database, respectively.

The API exposes underlying jsonwall interfaces for both reading and
writing. An attempt was made to build an abstraction on top of jsonwall,
but it was later abandoned because of Go type system limitations and
difficulty to test.

The schema is set to 0.1 when writing. An error is returned when the
schema isn't 0.1 when reading. The schema and database location in the
output root directory are implementation details that are not exposed by
the API.