### PR TITLE
extract: Proper modes with multiple copies

### DIFF
--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -332,6 +332,39 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 	c.Assert(err, ErrorMatches, `.*\bno Ubuntu section`)
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+	}
+
+	archive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1 := archive.Info("mypkg1")
+	c.Assert(info1, NotNil)
+	c.Assert(info1.Name(), Equals, "mypkg1")
+	c.Assert(info1.Version(), Equals, "1.1")
+	c.Assert(info1.Arch(), Equals, "amd64")
+	c.Assert(info1.SHA256(), Equals, "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05")
+
+	info3 := archive.Info("mypkg3")
+	c.Assert(info3, NotNil)
+	c.Assert(info3.Name(), Equals, "mypkg3")
+	c.Assert(info3.Version(), Equals, "1.3")
+	c.Assert(info3.Arch(), Equals, "amd64")
+	c.Assert(info3.SHA256(), Equals, "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa")
+
+	info99 := archive.Info("mypkg99")
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -245,6 +245,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 		}
 
 		var pathReader io.Reader = tarReader
+		origMode := tarHeader.Mode
 		for _, extractInfo := range extractInfos {
 			if contentIsCached {
 				pathReader = bytes.NewReader(contentCache)
@@ -258,6 +259,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			if err := createParents(targetPath); err != nil {
 				return err
 			}
+			tarHeader.Mode = origMode
 			if extractInfo.Mode != 0 {
 				tarHeader.Mode = int64(extractInfo.Mode)
 			}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -413,6 +413,32 @@ var extractTests = []extractTest{{
 		"/a/b/c/":  "dir 0706",
 		"/a/b/c/d": "file 0601 empty",
 	},
+}, {
+	summary: "Copies with different permissions",
+	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
+		Dir(0701, "./a/"),
+		Reg(0601, "./b", ""),
+	}),
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/a/": []deb.ExtractInfo{
+				{Path: "/b/"},
+				{Path: "/c/", Mode: 0702},
+				{Path: "/d/", Mode: 01777},
+				{Path: "/e/"},
+				{Path: "/f/", Mode: 0723},
+				{Path: "/g/"},
+			},
+		},
+	},
+	result: map[string]string{
+		"/b/": "dir 0701",
+		"/c/": "dir 0702",
+		"/d/": "dir 01777",
+		"/e/": "dir 0701",
+		"/f/": "dir 0723",
+		"/g/": "dir 0701",
+	},
 }}
 
 func (s *S) TestExtract(c *C) {

--- a/internal/fsutil/path.go
+++ b/internal/fsutil/path.go
@@ -1,0 +1,66 @@
+package fsutil
+
+import (
+	"path/filepath"
+)
+
+// isDirPath returns whether the path refers to a directory.
+// The path refers to a directory when it ends with "/", "/." or "/..", or when
+// it equals "." or "..".
+func isDirPath(path string) bool {
+	i := len(path) - 1
+	if i < 0 {
+		return true
+	}
+	if path[i] == '.' {
+		i--
+		if i < 0 {
+			return true
+		}
+		if path[i] == '.' {
+			i--
+			if i < 0 {
+				return true
+			}
+		}
+	}
+	if path[i] == '/' {
+		return true
+	}
+	return false
+}
+
+// Debian package tarballs present paths slightly differently to what we would
+// normally classify as clean paths. While a traditional clean file path is identical
+// to a clean deb package file path, the deb package directory path always ends
+// with a slash. Although the change only affects directory paths, the implication
+// is that a directory path without a slash is interpreted as a file path. For this
+// reason, we need to be very careful and handle both file and directory paths using
+// a new set of functions. We call this new path type a Slashed Path. A slashed path
+// allows us to identify a file or directory simply using lexical analysis.
+
+// SlashedPathClean takes a file or slashed directory path as input, and produces
+// the shortest equivalent as output. An input path ending without a slash will be
+// interpreted as a file path. Directory paths should always end with a slash.
+// These functions exists because we work with slash terminated directory paths
+// that come from deb package tarballs but standard library path functions
+// treat slash terminated paths as unclean.
+func SlashedPathClean(path string) string {
+	clean := filepath.Clean(path)
+	if clean != "/" && isDirPath(path) {
+		clean += "/"
+	}
+	return clean
+}
+
+// SlashedPathDir takes a file or slashed directory path as input, cleans the
+// path and returns the parent directory. An input path ending without a slash
+// will be interpreted as a file path. Directory paths should always end with a slash.
+// Clean is like filepath.Clean() but trailing slash is kept.
+func SlashedPathDir(path string) string {
+	parent := filepath.Dir(filepath.Clean(path))
+	if parent != "/" {
+		parent += "/"
+	}
+	return parent
+}

--- a/internal/fsutil/path_test.go
+++ b/internal/fsutil/path_test.go
@@ -1,0 +1,54 @@
+package fsutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/fsutil"
+)
+
+var cleanAndDirTestCases = []struct {
+	inputPath   string
+	resultClean string
+	resultDir   string
+}{
+	{"/a/b/c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/c//", "/a/b/c/", "/a/b/"},
+	{"/a/b//c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/.", "/a/b/c/", "/a/b/"},
+	{"/a/b/c/.///.", "/a/b/c/", "/a/b/"},
+	{"/a/b/./c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/.///./c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/..", "/a/b/", "/a/"},
+	{"/a/b/c/..///./", "/a/b/", "/a/"},
+	{"/a/b/c/../.", "/a/b/", "/a/"},
+	{"/a/b/../c/", "/a/c/", "/a/"},
+	{"/a/b/..///./c", "/a/c", "/a/"},
+	{"a/b/./c", "a/b/c", "a/b/"},
+	{"./a/b/./c", "a/b/c", "a/b/"},
+	{"/", "/", "/"},
+	{"///", "/", "/"},
+	{"///.///", "/", "/"},
+	{"/././.", "/", "/"},
+	{".", "./", "./"},
+	{".///", "./", "./"},
+	{"..", "../", "./"},
+	{"..///.", "../", "./"},
+	{"../../..", "../../../", "../../"},
+	{"..///.///../..", "../../../", "../../"},
+	{"", "./", "./"},
+}
+
+func (s *S) TestSlashedPathClean(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultClean)
+		c.Assert(fsutil.SlashedPathClean(t.inputPath), Equals, t.resultClean)
+	}
+}
+
+func (s *S) TestSlashedPathDir(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultDir)
+		c.Assert(fsutil.SlashedPathDir(t.inputPath), Equals, t.resultDir)
+	}
+}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -109,14 +109,13 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := fsutil.SlashedPathDir(targetPath)
-				if targetDir == "" || targetDir == "/" {
-					continue
+				parent := fsutil.SlashedPathDir(targetPath)
+				for ; parent != "/"; parent = fsutil.SlashedPathDir(parent) {
+					extractPackage[parent] = append(extractPackage[parent], deb.ExtractInfo{
+						Path:     parent,
+						Optional: true,
+					})
 				}
-				extractPackage[targetDir] = append(extractPackage[targetDir], deb.ExtractInfo{
-					Path:     targetDir,
-					Optional: true,
-				})
 			}
 		}
 		if !hasCopyright {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -32,25 +32,21 @@ func Run(options *RunOptions) error {
 
 	knownPaths["/"] = true
 
+	// addKnownPath path adds path and all its directory parent paths into
+	// knownPaths set.
 	addKnownPath := func(path string) {
 		if path[0] != '/' {
 			panic("bug: tried to add relative path to known paths")
 		}
-		cleanPath := filepath.Clean(path)
-		slashPath := cleanPath
-		if path[len(path)-1] == '/' && cleanPath != "/" {
-			slashPath += "/"
-		}
+		path = fsutil.SlashedPathClean(path)
 		for {
-			if _, ok := knownPaths[slashPath]; ok {
+			if _, ok := knownPaths[path]; ok {
 				break
 			}
-			knownPaths[slashPath] = true
-			cleanPath = filepath.Dir(cleanPath)
-			if cleanPath == "/" {
+			knownPaths[path] = true
+			if path = fsutil.SlashedPathDir(path); path == "/" {
 				break
 			}
-			slashPath = cleanPath + "/"
 		}
 	}
 
@@ -113,7 +109,7 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := filepath.Dir(strings.TrimRight(targetPath, "/")) + "/"
+				targetDir := fsutil.SlashedPathDir(targetPath)
 				if targetDir == "" || targetDir == "/" {
 					continue
 				}


### PR DESCRIPTION
We use the source tar entry header to compute fs.FileMode. When the
target path has a different mode, we modify the source header first.
Consequently, when a source path is mapped to multiple target paths, and
when one target path overrides the mode and the following one doesn't,
the following one will have the first one's mode. Fix it by remembering
the source header mode.