### PR TITLE
fsutil: Explicit parent directory creation

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -189,6 +189,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				err := fsutil.Create(&fsutil.CreateOptions{
 					Path: filepath.Join(options.TargetDir, sourcePath),
 					Mode: tarHeader.FileInfo().Mode(),
+					Dirs: true,
 				})
 				if err != nil {
 					return err
@@ -231,6 +232,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				Mode: tarHeader.FileInfo().Mode(),
 				Data: pathReader,
 				Link: tarHeader.Linkname,
+				Dirs: true,
 			})
 			if err != nil {
 				return err

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -23,6 +23,7 @@ var createTests = []createTest{{
 		Path: "foo/bar",
 		Data: bytes.NewBufferString("data1"),
 		Mode: 0444,
+		Dirs: true,
 	},
 	result: map[string]string{
 		"/foo/":    "dir 0755",
@@ -33,6 +34,7 @@ var createTests = []createTest{{
 		Path: "foo/bar",
 		Link: "../baz",
 		Mode: fs.ModeSymlink,
+		Dirs: true,
 	},
 	result: map[string]string{
 		"/foo/":    "dir 0755",
@@ -42,6 +44,7 @@ var createTests = []createTest{{
 	options: fsutil.CreateOptions{
 		Path: "foo/bar",
 		Mode: fs.ModeDir | 0444,
+		Dirs: true,
 	},
 	result: map[string]string{
 		"/foo/":     "dir 0755",
@@ -55,6 +58,12 @@ var createTests = []createTest{{
 	result: map[string]string{
 		"/tmp/":     "dir 01775",
 	},
+}, {
+	options: fsutil.CreateOptions{
+		Path: "foo/bar",
+		Mode: fs.ModeDir | 0775,
+	},
+	error: `.*: no such file or directory`,
 }}
 
 func (s *S) TestCreate(c *C) {

--- a/internal/setup/fetch.go
+++ b/internal/setup/fetch.go
@@ -143,6 +143,7 @@ func extractTar(dataReader io.Reader, targetDir string) error {
 			Mode: tarHeader.FileInfo().Mode(),
 			Data: tarReader,
 			Link: tarHeader.Linkname,
+			Dirs: true,
 		})
 		if err != nil {
 			return err

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -216,6 +216,7 @@ func Run(options *RunOptions) error {
 				Mode: tarHeader.FileInfo().Mode(),
 				Data: fileContent,
 				Link: linkTarget,
+				Dirs: true,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently fsutil.Create() always creates missing parent directories with
0755 mode. While this is handy for some use cases, during extraction we
want to create every path with attributes from the tarball and having
parent directories created automatically hides the bugs where we fail to
create some directories from the tarball.

One such bug is when globs are used. In this case, the directories
before wildcards are ignored when encountered in the tarball. Instead,
they are created by os.MkdirAll() in fsutil.Create() for paths matching
the glob.

Don't fix the bugs now but make the creation of the parent directories
explicit in CreateOptions with the Dirs attribute. Later, we will drop
it from call sites where appropriate.