### PR TITLE
slicer: Track and record paths in DB

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/chisel/internal/archive"
 	"github.com/canonical/chisel/internal/cache"
+	"github.com/canonical/chisel/internal/db"
 	"github.com/canonical/chisel/internal/setup"
 	"github.com/canonical/chisel/internal/slicer"
 )
@@ -98,11 +99,19 @@ func (cmd *cmdCut) Execute(args []string) error {
 		archives[archiveName] = openArchive
 	}
 
-	return slicer.Run(&slicer.RunOptions{
+	dbw := db.New()
+
+	err = slicer.Run(&slicer.RunOptions{
 		Selection: selection,
 		Archives:  archives,
 		TargetDir: cmd.RootDir,
+		AddToDB:   dbw.Add,
 	})
+	if err != nil {
+		return err
+	}
+
+	return db.Save(dbw, cmd.RootDir)
 }
 
 // TODO These need testing, and maybe moving into a common file.

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -332,6 +332,39 @@ func (s *httpSuite) TestArchiveLabels(c *C) {
 	c.Assert(err, ErrorMatches, `.*\bno Ubuntu section`)
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+	}
+
+	archive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1 := archive.Info("mypkg1")
+	c.Assert(info1, NotNil)
+	c.Assert(info1.Name(), Equals, "mypkg1")
+	c.Assert(info1.Version(), Equals, "1.1")
+	c.Assert(info1.Arch(), Equals, "amd64")
+	c.Assert(info1.SHA256(), Equals, "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05")
+
+	info3 := archive.Info("mypkg3")
+	c.Assert(info3, NotNil)
+	c.Assert(info3.Name(), Equals, "mypkg3")
+	c.Assert(info3.Version(), Equals, "1.3")
+	c.Assert(info3.Arch(), Equals, "amd64")
+	c.Assert(info3.SHA256(), Equals, "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa")
+
+	info99 := archive.Info("mypkg99")
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/chisel/internal/jsonwall"
+	"github.com/klauspost/compress/zstd"
+)
+
+const schema = "0.1"
+
+// New creates a new Chisel DB writer with the proper schema.
+func New() *jsonwall.DBWriter {
+	options := jsonwall.DBWriterOptions{Schema: schema}
+	return jsonwall.NewDBWriter(&options)
+}
+
+func getDBPath(root string) string {
+	return filepath.Join(root, ".chisel.db")
+}
+
+// Save uses the provided writer dbw to write the Chisel DB into the standard
+// path under the provided root directory.
+func Save(dbw *jsonwall.DBWriter, root string) (err error) {
+	dbPath := getDBPath(root)
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot save state to %q: %w", dbPath, err)
+		}
+	}()
+	f, err := os.OpenFile(dbPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	// chmod the existing file
+	if err = f.Chmod(0644); err != nil {
+		return
+	}
+	zw, err := zstd.NewWriter(f)
+	if err != nil {
+		return
+	}
+	if _, err = dbw.WriteTo(zw); err != nil {
+		return
+	}
+	return zw.Close()
+}
+
+// Load reads a Chisel DB from the standard path under the provided root
+// directory. If the Chisel DB doesn't exist, the returned error satisfies
+// errors.Is(err, fs.ErrNotExist))
+func Load(root string) (db *jsonwall.DB, err error) {
+	dbPath := getDBPath(root)
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot load state from %q: %w", dbPath, err)
+		}
+	}()
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		return
+	}
+	defer zr.Close()
+	db, err = jsonwall.ReadDB(zr)
+	if err != nil {
+		return nil, err
+	}
+	if s := db.Schema(); s != schema {
+		return nil, fmt.Errorf("invalid schema %#v", s)
+	}
+	return
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,74 @@
+package db_test
+
+import (
+	"sort"
+
+	"github.com/canonical/chisel/internal/db"
+	. "gopkg.in/check.v1"
+)
+
+type testEntry struct {
+	S string          `json:"s,omitempty"`
+	I int64           `json:"i,omitempty"`
+	L []string        `json:"l,omitempty"`
+	M map[string]bool `json:"m,omitempty"`
+}
+
+var saveLoadTestCase = []testEntry{
+	{"", 0, nil, nil},
+	{"hello", -1, nil, nil},
+	{"", 0, nil, nil},
+	{"", 100, []string{"a", "b"}, nil},
+	{"", 0, nil, map[string]bool{"a": true, "b": false}},
+	{"abc", 123, []string{"foo", "bar"}, nil},
+}
+
+func (s *S) TestSaveLoadRoundTrip(c *C) {
+	// To compare expected and obtained entries we first wrap the original
+	// entries in wrappers with increasing K. When we read the wrappers back
+	// they may be in different order because jsonwall sorts them serialized
+	// as JSON. So we sort them by K to compare them in the original order.
+
+	type wrapper struct {
+		// test values
+		testEntry
+		// sort key for comparison
+		K int `json:"key"`
+	}
+
+	// wrap the entries with increasing K
+	expected := make([]wrapper, len(saveLoadTestCase))
+	for i, entry := range saveLoadTestCase {
+		expected[i] = wrapper{entry, i}
+	}
+
+	workDir := c.MkDir()
+	dbw := db.New()
+	for _, entry := range expected {
+		err := dbw.Add(entry)
+		c.Assert(err, IsNil)
+	}
+	err := db.Save(dbw, workDir)
+	c.Assert(err, IsNil)
+
+	dbr, err := db.Load(workDir)
+	c.Assert(err, IsNil)
+	c.Assert(dbr.Schema(), Equals, db.Schema)
+
+	iter, err := dbr.Iterate(nil)
+	c.Assert(err, IsNil)
+
+	obtained := make([]wrapper, 0, len(expected))
+	for iter.Next() {
+		var wrapped wrapper
+		err := iter.Get(&wrapped)
+		c.Assert(err, IsNil)
+		obtained = append(obtained, wrapped)
+	}
+
+	// sort the entries by K to get the original order
+	sort.Slice(obtained, func(i, j int) bool {
+		return obtained[i].K < obtained[j].K
+	})
+	c.Assert(obtained, DeepEquals, expected)
+}

--- a/internal/db/export_test.go
+++ b/internal/db/export_test.go
@@ -1,0 +1,3 @@
+package db
+
+var Schema = schema

--- a/internal/db/suite_test.go
+++ b/internal/db/suite_test.go
@@ -1,0 +1,15 @@
+package db_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct{}
+
+var _ = Suite(&S{})

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1,0 +1,218 @@
+package db
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"strconv"
+)
+
+func decodeDigest(str string) (*[sha256.Size]byte, error) {
+	if str == "" {
+		return nil, nil
+	}
+	if len(str) != 2*sha256.Size {
+		return nil, fmt.Errorf("length %d != %d", len(str), 2*sha256.Size)
+	}
+	sl, err := hex.DecodeString(str)
+	if err != nil {
+		return nil, err
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], sl)
+	return &digest, nil
+}
+
+// The *alias types exist to avoid recursive marshaling, see
+// https://choly.ca/post/go-json-marshalling/.
+
+// Package represents a package that was sliced
+type Package struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	// package digests in chisel are used only in hex encoding so there's
+	// currently no need to store them as byte arrays
+	SHA256 string `json:"sha256"`
+	Arch   string `json:"arch"`
+}
+
+type packageAlias Package
+
+type jsonPackage struct {
+	Kind string `json:"kind"`
+	packageAlias
+}
+
+func (t Package) MarshalJSON() ([]byte, error) {
+	j := jsonPackage{"package", packageAlias(t)}
+	return json.Marshal(j)
+}
+
+func (t *Package) UnmarshalJSON(data []byte) error {
+	j := jsonPackage{}
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.Kind != "package" {
+		return fmt.Errorf(`invalid kind %q: must be "package"`, j.Kind)
+	}
+	*t = Package(j.packageAlias)
+	return nil
+}
+
+// Slice represents a slice of a package that was installed
+type Slice struct {
+	Name string `json:"name"`
+}
+
+type sliceAlias Slice
+
+type jsonSlice struct {
+	Kind string `json:"kind"`
+	sliceAlias
+}
+
+func (t Slice) MarshalJSON() ([]byte, error) {
+	j := jsonSlice{"slice", sliceAlias(t)}
+	return json.Marshal(j)
+}
+
+func (t *Slice) UnmarshalJSON(data []byte) error {
+	j := jsonSlice{}
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.Kind != "slice" {
+		return fmt.Errorf(`invalid kind %q: must be "slice"`, j.Kind)
+	}
+	*t = Slice(j.sliceAlias)
+	return nil
+}
+
+// Path represents a path that was sliced from a package.
+//
+// The filesystem object type can be determined from Path's fields:
+//
+//	a) If the SHA256 attribute is non-nil, this Path refers to a regular file,
+//	   its Path attribute must not end with /, and its Link attribute must be
+//	   empty.
+//	c) Otherwise, if the Link attribute is not empty, this Path refers to a
+//	   symbolic link.
+//	c) Otherwise, this Path refers to a directory, and its Path attribute must
+//	   end with /.
+//
+// If the Path refers to a regular file and its FinalSHA256 attribute is
+// non-nil, the SHA256 attribute must have a different value, and this Path
+// represents a regular file whose content in the package had digest equal to
+// the SHA256 attribute, but its content has changed during the installation
+// and the final digest of the content is equal to the FinalSHA256 attribute.
+type Path struct {
+	Path        string
+	Mode        fs.FileMode
+	Slices      []string
+	SHA256      *[sha256.Size]byte
+	FinalSHA256 *[sha256.Size]byte
+	Size        int64
+	Link        string
+}
+
+type jsonPath struct {
+	Kind        string   `json:"kind"`
+	Path        string   `json:"path"`
+	Mode        string   `json:"mode"`
+	Slices      []string `json:"slices"`
+	SHA256      string   `json:"sha256,omitempty"`
+	FinalSHA256 string   `json:"final_sha256,omitempty"`
+	Size        *int64   `json:"size,omitempty"`
+	Link        string   `json:"link,omitempty"`
+}
+
+func (t Path) MarshalJSON() ([]byte, error) {
+	j := jsonPath{
+		Kind:   "path",
+		Path:   t.Path,
+		Mode:   fmt.Sprintf("%#o", t.Mode),
+		Slices: t.Slices,
+		Link:   t.Link,
+	}
+	if t.Slices == nil {
+		j.Slices = []string{}
+	}
+	if t.SHA256 != nil {
+		j.SHA256 = fmt.Sprintf("%x", *t.SHA256)
+		if t.FinalSHA256 != nil {
+			j.FinalSHA256 = fmt.Sprintf("%x", *t.FinalSHA256)
+		}
+		j.Size = &t.Size
+	}
+	return json.Marshal(j)
+}
+
+func (t *Path) UnmarshalJSON(data []byte) error {
+	j := jsonPath{}
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.Kind != "path" {
+		return fmt.Errorf(`invalid kind %q: must be "path"`, j.Kind)
+	}
+	mode, err := strconv.ParseUint(j.Mode, 8, 32)
+	if err != nil {
+		return fmt.Errorf("invalid mode %#v: %w", j.Mode, err)
+	}
+	digest, err := decodeDigest(j.SHA256)
+	if err != nil {
+		return fmt.Errorf("invalid sha256 %#v: %w", j.SHA256, err)
+	}
+	finalDigest, err := decodeDigest(j.FinalSHA256)
+	if err != nil {
+		return fmt.Errorf("invalid final_sha256 %#v: %w", j.SHA256, err)
+	}
+	t.Path = j.Path
+	t.Mode = fs.FileMode(mode)
+	t.Slices = j.Slices
+	if t.Slices != nil && len(t.Slices) == 0 {
+		t.Slices = nil
+	}
+	t.SHA256 = digest
+	t.FinalSHA256 = finalDigest
+	t.Size = 0
+	if j.Size != nil {
+		t.Size = *j.Size
+	}
+	t.Link = j.Link
+	return nil
+}
+
+// Content represents an ownership of a path by a slice. There can be more than
+// one slice owning a path.
+type Content struct {
+	Slice string `json:"slice"`
+	Path  string `json:"path"`
+}
+
+type contentAlias Content
+
+type jsonContent struct {
+	Kind string `json:"kind"`
+	contentAlias
+}
+
+func (t Content) MarshalJSON() ([]byte, error) {
+	j := jsonContent{"content", contentAlias(t)}
+	return json.Marshal(j)
+}
+
+func (t *Content) UnmarshalJSON(data []byte) error {
+	j := jsonContent{}
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	if j.Kind != "content" {
+		return fmt.Errorf(`invalid kind %q: must be "content"`, j.Kind)
+	}
+	*t = Content(j.contentAlias)
+	return nil
+}

--- a/internal/db/types_test.go
+++ b/internal/db/types_test.go
@@ -1,0 +1,188 @@
+package db_test
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/canonical/chisel/internal/db"
+	. "gopkg.in/check.v1"
+)
+
+type roundTripTestCase struct {
+	value any
+	json  string
+}
+
+var roundTripTestCases = []roundTripTestCase{{
+	db.Package{"foo", "bar", "", ""},
+	`{"kind":"package","name":"foo","version":"bar","sha256":"","arch":""}`,
+}, {
+	db.Package{"coolutils", "1.2-beta", "bbbaa816dedc5c5d58e30e7ed600fe62ea0208ef2d6fac4da8b312d113401958", "all"},
+	`{"kind":"package","name":"coolutils","version":"1.2-beta","sha256":"bbbaa816dedc5c5d58e30e7ed600fe62ea0208ef2d6fac4da8b312d113401958","arch":"all"}`,
+}, {
+	db.Package{"badcowboys", "7", "d0aba6d028cd4a3fd153eb5e0bfb35c33f4d5674b80a7a827917df40e1192424", "amd64"},
+	`{"kind":"package","name":"badcowboys","version":"7","sha256":"d0aba6d028cd4a3fd153eb5e0bfb35c33f4d5674b80a7a827917df40e1192424","arch":"amd64"}`,
+}, {
+	db.Slice{"elitestrike_bins"},
+	`{"kind":"slice","name":"elitestrike_bins"}`,
+}, {
+	db.Slice{"invalid but unmarshals"},
+	`{"kind":"slice","name":"invalid but unmarshals"}`,
+}, {
+	db.Path{
+		Path:   "/bin/snake",
+		Mode:   0755,
+		Slices: []string{"snake_bins"},
+		SHA256: &[...]byte{
+			0xa0, 0x1b, 0xab, 0x26, 0xf0, 0x8b, 0xa8, 0x7b, 0x86,
+			0x73, 0x63, 0x68, 0xb0, 0x68, 0x4f, 0x08, 0x49, 0xa3,
+			0x65, 0xab, 0x4c, 0x5e, 0xc5, 0x46, 0xd9, 0x73, 0xca,
+			0x87, 0xc8, 0x15, 0xf6, 0x82,
+		},
+		Size: 13,
+	},
+	`{"kind":"path","path":"/bin/snake","mode":"0755","slices":["snake_bins"],"sha256":"a01bab26f08ba87b86736368b0684f0849a365ab4c5ec546d973ca87c815f682","size":13}`,
+}, {
+	db.Path{
+		Path:   "/etc/default/",
+		Mode:   0750,
+		Slices: []string{"someconfig_data", "mytoo_data"},
+	},
+	`{"kind":"path","path":"/etc/default/","mode":"0750","slices":["someconfig_data","mytoo_data"]}`,
+}, {
+	db.Path{
+		Path:   "/var/lib/matt/index.data",
+		Mode:   0600,
+		Slices: []string{"daemon_data"},
+		SHA256: &[...]byte{
+			0x06, 0x82, 0xc5, 0xf2, 0x07, 0x6f, 0x09, 0x9c, 0x34,
+			0xcf, 0xdd, 0x15, 0xa9, 0xe0, 0x63, 0x84, 0x9e, 0xd4,
+			0x37, 0xa4, 0x96, 0x77, 0xe6, 0xfc, 0xc5, 0xb4, 0x19,
+			0x8c, 0x76, 0x57, 0x5b, 0xe5,
+		},
+		FinalSHA256: &[...]byte{
+			0xd7, 0xd5, 0xdc, 0xc3, 0x69, 0x42, 0x6e, 0x2e, 0x5f,
+			0x8d, 0xcb, 0x89, 0xaf, 0x43, 0x08, 0xb0, 0xda, 0xed,
+			0x6e, 0x55, 0x91, 0x0d, 0x53, 0x39, 0x5c, 0xe3, 0x8b,
+			0xd6, 0xdd, 0x1a, 0x94, 0x56,
+		},
+		Size: 999,
+	},
+	`{"kind":"path","path":"/var/lib/matt/index.data","mode":"0600","slices":["daemon_data"],"sha256":"0682c5f2076f099c34cfdd15a9e063849ed437a49677e6fcc5b4198c76575be5","final_sha256":"d7d5dcc369426e2e5f8dcb89af4308b0daed6e55910d53395ce38bd6dd1a9456","size":999}`,
+}, {
+	db.Path{
+		Path:   "/etc/config",
+		Mode:   0644,
+		SHA256: &[32]byte{},
+	},
+	`{"kind":"path","path":"/etc/config","mode":"0644","slices":[],"sha256":"0000000000000000000000000000000000000000000000000000000000000000","size":0}`,
+}, {
+	db.Path{
+		Path:   "/lib",
+		Mode:   0777,
+		Slices: []string{"libc6_libs", "zlib1g_libs"},
+		Link:   "/usr/lib/",
+	},
+	`{"kind":"path","path":"/lib","mode":"0777","slices":["libc6_libs","zlib1g_libs"],"link":"/usr/lib/"}`,
+}, {
+	db.Path{},
+	`{"kind":"path","path":"","mode":"0","slices":[]}`,
+}, {
+	db.Path{Mode: 077777},
+	`{"kind":"path","path":"","mode":"077777","slices":[]}`,
+}, {
+	db.Content{"foo_sl", "/a/b/c"},
+	`{"kind":"content","slice":"foo_sl","path":"/a/b/c"}`,
+}}
+
+func (s *S) TestMarshalUnmarshalRoundTrip(c *C) {
+	for i, test := range roundTripTestCases {
+		c.Logf("Test #%d", i)
+		data, err := json.Marshal(test.value)
+		c.Assert(err, IsNil)
+		c.Assert(string(data), DeepEquals, test.json)
+		ptrOut := reflect.New(reflect.ValueOf(test.value).Type())
+		err = json.Unmarshal(data, ptrOut.Interface())
+		c.Assert(err, IsNil)
+		c.Assert(ptrOut.Elem().Interface(), DeepEquals, test.value)
+	}
+}
+
+type unmarshalTestCase struct {
+	json  string
+	value any
+	error string
+}
+
+var unmarshalTestCases = []unmarshalTestCase{{
+	json:  `{"kind":"package","name":"pkg","version":"1.1","sha256":"d0aba6d028cd4a3fd153eb5e0bfb35c33f4d5674b80a7a827917df40e1192424","arch":"all"}`,
+	value: db.Package{"pkg", "1.1", "d0aba6d028cd4a3fd153eb5e0bfb35c33f4d5674b80a7a827917df40e1192424", "all"},
+}, {
+	json:  `{"kind":"slice","name":"a"}`,
+	value: db.Slice{"a"},
+}, {
+	json: `{"kind":"path","path":"/x/y/z","mode":"0644","slices":["pkg1_data","pkg2_data"],"sha256":"f177b37f18f5bc6596878f074721d796c2333d95f26ce1e45c5a096c350a1c07","final_sha256":"61bd495076999a77f75288fcfcdd76073ec4aa114632a310b3b3263c498e12f7","size":123}`,
+	value: db.Path{
+		Path:   "/x/y/z",
+		Mode:   0644,
+		Slices: []string{"pkg1_data", "pkg2_data"},
+		SHA256: &[...]byte{
+			0xf1, 0x77, 0xb3, 0x7f, 0x18, 0xf5, 0xbc, 0x65, 0x96,
+			0x87, 0x8f, 0x07, 0x47, 0x21, 0xd7, 0x96, 0xc2, 0x33,
+			0x3d, 0x95, 0xf2, 0x6c, 0xe1, 0xe4, 0x5c, 0x5a, 0x09,
+			0x6c, 0x35, 0x0a, 0x1c, 0x07,
+		},
+		FinalSHA256: &[...]byte{
+			0x61, 0xbd, 0x49, 0x50, 0x76, 0x99, 0x9a, 0x77, 0xf7,
+			0x52, 0x88, 0xfc, 0xfc, 0xdd, 0x76, 0x07, 0x3e, 0xc4,
+			0xaa, 0x11, 0x46, 0x32, 0xa3, 0x10, 0xb3, 0xb3, 0x26,
+			0x3c, 0x49, 0x8e, 0x12, 0xf7,
+		},
+		Size: 123,
+	},
+}, {
+	json:  `{"kind":"path","path":"/x/y/z","mode":"0777","slices":[],"link":"/home"}`,
+	value: db.Path{Path: "/x/y/z", Mode: 0777, Link: "/home"},
+}, {
+	json:  `{"kind":"path","path":"/x/y/z","mode":"0","slices":null}`,
+	value: db.Path{Path: "/x/y/z"},
+}, {
+	json:  `{"kind":"path","path":"/x/y/z","mode":"0"}`,
+	value: db.Path{Path: "/x/y/z"},
+}, {
+	json:  `{"kind":"content","slice":"pkg_sl","path":"/a/b/c"}`,
+	value: db.Content{Slice: "pkg_sl", Path: "/a/b/c"},
+}, {
+	json:  `{"kind":"path","path":"","mode":"90909"}`,
+	value: db.Path{},
+	error: `invalid mode "90909": strconv.ParseUint: parsing "90909": invalid syntax`,
+}, {
+	json:  `{"kind":"path","path":"","mode":"077777777777"}`,
+	value: db.Path{},
+	error: `invalid mode "077777777777": strconv.ParseUint: parsing "077777777777": value out of range`,
+}, {
+	json:  `{"kind":"path","path":"/tmp/abc.txt","mode":"0644","sha256":"too short"}`,
+	value: db.Path{},
+	error: `invalid sha256 "too short": length 9 != 64`,
+}, {
+	json:  `{"kind":"path","path":"/tmp/abc.txt","mode":"0644","sha256":"gfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}`,
+	value: db.Path{},
+	error: `invalid sha256 "gfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": encoding/hex: invalid byte: U\+0067 'g'`,
+}, {
+	json:  `{"kind":"package","name":"foo_libs"}`,
+	value: db.Slice{},
+	error: `invalid kind "package": must be "slice"`,
+}}
+
+func (s *S) TestUnmarshal(c *C) {
+	for i, test := range unmarshalTestCases {
+		c.Logf("Test #%d", i)
+		ptrOut := reflect.New(reflect.ValueOf(test.value).Type())
+		err := json.Unmarshal([]byte(test.json), ptrOut.Interface())
+		if test.error != "" {
+			c.Assert(err, ErrorMatches, test.error)
+		} else {
+			c.Assert(ptrOut.Elem().Interface(), DeepEquals, test.value)
+		}
+	}
+}

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -245,6 +245,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 		}
 
 		var pathReader io.Reader = tarReader
+		origMode := tarHeader.Mode
 		for _, extractInfo := range extractInfos {
 			if contentIsCached {
 				pathReader = bytes.NewReader(contentCache)
@@ -258,6 +259,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			if err := createParents(targetPath); err != nil {
 				return err
 			}
+			tarHeader.Mode = origMode
 			if extractInfo.Mode != 0 {
 				tarHeader.Mode = int64(extractInfo.Mode)
 			}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -413,6 +413,32 @@ var extractTests = []extractTest{{
 		"/a/b/c/":  "dir 0706",
 		"/a/b/c/d": "file 0601 empty",
 	},
+}, {
+	summary: "Copies with different permissions",
+	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
+		Dir(0701, "./a/"),
+		Reg(0601, "./b", ""),
+	}),
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/a/": []deb.ExtractInfo{
+				{Path: "/b/"},
+				{Path: "/c/", Mode: 0702},
+				{Path: "/d/", Mode: 01777},
+				{Path: "/e/"},
+				{Path: "/f/", Mode: 0723},
+				{Path: "/g/"},
+			},
+		},
+	},
+	result: map[string]string{
+		"/b/": "dir 0701",
+		"/c/": "dir 0702",
+		"/d/": "dir 01777",
+		"/e/": "dir 0701",
+		"/f/": "dir 0723",
+		"/g/": "dir 0701",
+	},
 }}
 
 func (s *S) TestExtract(c *C) {

--- a/internal/fsutil/path.go
+++ b/internal/fsutil/path.go
@@ -1,0 +1,66 @@
+package fsutil
+
+import (
+	"path/filepath"
+)
+
+// isDirPath returns whether the path refers to a directory.
+// The path refers to a directory when it ends with "/", "/." or "/..", or when
+// it equals "." or "..".
+func isDirPath(path string) bool {
+	i := len(path) - 1
+	if i < 0 {
+		return true
+	}
+	if path[i] == '.' {
+		i--
+		if i < 0 {
+			return true
+		}
+		if path[i] == '.' {
+			i--
+			if i < 0 {
+				return true
+			}
+		}
+	}
+	if path[i] == '/' {
+		return true
+	}
+	return false
+}
+
+// Debian package tarballs present paths slightly differently to what we would
+// normally classify as clean paths. While a traditional clean file path is identical
+// to a clean deb package file path, the deb package directory path always ends
+// with a slash. Although the change only affects directory paths, the implication
+// is that a directory path without a slash is interpreted as a file path. For this
+// reason, we need to be very careful and handle both file and directory paths using
+// a new set of functions. We call this new path type a Slashed Path. A slashed path
+// allows us to identify a file or directory simply using lexical analysis.
+
+// SlashedPathClean takes a file or slashed directory path as input, and produces
+// the shortest equivalent as output. An input path ending without a slash will be
+// interpreted as a file path. Directory paths should always end with a slash.
+// These functions exists because we work with slash terminated directory paths
+// that come from deb package tarballs but standard library path functions
+// treat slash terminated paths as unclean.
+func SlashedPathClean(path string) string {
+	clean := filepath.Clean(path)
+	if clean != "/" && isDirPath(path) {
+		clean += "/"
+	}
+	return clean
+}
+
+// SlashedPathDir takes a file or slashed directory path as input, cleans the
+// path and returns the parent directory. An input path ending without a slash
+// will be interpreted as a file path. Directory paths should always end with a slash.
+// Clean is like filepath.Clean() but trailing slash is kept.
+func SlashedPathDir(path string) string {
+	parent := filepath.Dir(filepath.Clean(path))
+	if parent != "/" {
+		parent += "/"
+	}
+	return parent
+}

--- a/internal/fsutil/path_test.go
+++ b/internal/fsutil/path_test.go
@@ -1,0 +1,54 @@
+package fsutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/fsutil"
+)
+
+var cleanAndDirTestCases = []struct {
+	inputPath   string
+	resultClean string
+	resultDir   string
+}{
+	{"/a/b/c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/c//", "/a/b/c/", "/a/b/"},
+	{"/a/b//c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/.", "/a/b/c/", "/a/b/"},
+	{"/a/b/c/.///.", "/a/b/c/", "/a/b/"},
+	{"/a/b/./c/", "/a/b/c/", "/a/b/"},
+	{"/a/b/.///./c", "/a/b/c", "/a/b/"},
+	{"/a/b/c/..", "/a/b/", "/a/"},
+	{"/a/b/c/..///./", "/a/b/", "/a/"},
+	{"/a/b/c/../.", "/a/b/", "/a/"},
+	{"/a/b/../c/", "/a/c/", "/a/"},
+	{"/a/b/..///./c", "/a/c", "/a/"},
+	{"a/b/./c", "a/b/c", "a/b/"},
+	{"./a/b/./c", "a/b/c", "a/b/"},
+	{"/", "/", "/"},
+	{"///", "/", "/"},
+	{"///.///", "/", "/"},
+	{"/././.", "/", "/"},
+	{".", "./", "./"},
+	{".///", "./", "./"},
+	{"..", "../", "./"},
+	{"..///.", "../", "./"},
+	{"../../..", "../../../", "../../"},
+	{"..///.///../..", "../../../", "../../"},
+	{"", "./", "./"},
+}
+
+func (s *S) TestSlashedPathClean(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultClean)
+		c.Assert(fsutil.SlashedPathClean(t.inputPath), Equals, t.resultClean)
+	}
+}
+
+func (s *S) TestSlashedPathDir(c *C) {
+	for _, t := range cleanAndDirTestCases {
+		c.Logf("%s => %s", t.inputPath, t.resultDir)
+		c.Assert(fsutil.SlashedPathDir(t.inputPath), Equals, t.resultDir)
+	}
+}

--- a/internal/slicer/export_test.go
+++ b/internal/slicer/export_test.go
@@ -1,0 +1,3 @@
+package slicer
+
+type StringSet = stringSet

--- a/internal/slicer/fakedb_test.go
+++ b/internal/slicer/fakedb_test.go
@@ -1,0 +1,164 @@
+package slicer_test
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/canonical/chisel/internal/db"
+)
+
+// fakeDB is used to compare a list of DB objects created by the slicer against
+// a list of expected DB objects. We don't care about the order in which slicer
+// creates DB objects. In real usage, they will be reordered by the jsonwall
+// database anyway. We only care about the set of objects created. So we record
+// the created objects and put them into fakeDB and put the expected objects
+// into another fakeDB. Then, we compare both sets as sorted lists obtained
+// from fakeDB.values().
+//
+// Since DB object types are not ordered nor comparable (Path has pointers), we
+// keep different types of objects in different slices and sort these slices
+// with a comparison function appropriate for each type.
+
+type fakeDB struct {
+	packages []db.Package
+	slices   []db.Slice
+	paths    []db.Path
+	contents []db.Content
+}
+
+func (p *fakeDB) add(value any) error {
+	switch v := value.(type) {
+	case db.Package:
+		p.packages = append(p.packages, v)
+	case db.Slice:
+		p.slices = append(p.slices, v)
+	case db.Path:
+		p.paths = append(p.paths, v)
+	case db.Content:
+		p.contents = append(p.contents, v)
+	default:
+		return fmt.Errorf("invalid DB type %T", v)
+	}
+	return nil
+}
+
+func (p *fakeDB) values() []any {
+	sort.Slice(p.packages, func(i, j int) bool {
+		x1 := p.packages[i].Name
+		x2 := p.packages[j].Name
+		return x1 < x2
+	})
+	sort.Slice(p.slices, func(i, j int) bool {
+		x1 := p.slices[i].Name
+		x2 := p.slices[j].Name
+		return x1 < x2
+	})
+	sort.Slice(p.paths, func(i, j int) bool {
+		x1 := p.paths[i].Path
+		x2 := p.paths[j].Path
+		return x1 < x2
+	})
+	sort.Slice(p.contents, func(i, j int) bool {
+		x1 := p.contents[i].Slice
+		x2 := p.contents[j].Slice
+		y1 := p.contents[i].Path
+		y2 := p.contents[j].Path
+		return x1 < x2 || (x1 == x2 && y1 < y2)
+	})
+	i := 0
+	vals := make([]any, len(p.packages)+len(p.slices)+len(p.paths)+len(p.contents))
+	for _, v := range p.packages {
+		vals[i] = v
+		i++
+	}
+	for _, v := range p.slices {
+		vals[i] = v
+		i++
+	}
+	for _, v := range p.paths {
+		vals[i] = v
+		i++
+	}
+	for _, v := range p.contents {
+		vals[i] = v
+		i++
+	}
+	return vals
+}
+
+//nolint:unused
+func (p *fakeDB) dumpValues(w io.Writer) {
+	for _, v := range p.values() {
+		switch t := v.(type) {
+		case db.Package:
+			fmt.Fprintln(w, "db.Package{")
+			fmt.Fprintf(w, "\tName: %#v,\n", t.Name)
+			fmt.Fprintf(w, "\tVersion: %#v,\n", t.Version)
+			if t.SHA256 != "" {
+				fmt.Fprintf(w, "\tSHA256: %#v,\n", t.SHA256)
+			}
+			if t.Arch != "" {
+				fmt.Fprintf(w, "\tArch: %#v,\n", t.Arch)
+			}
+			fmt.Fprintln(w, "},")
+		case db.Slice:
+			fmt.Fprintln(w, "db.Slice{")
+			fmt.Fprintf(w, "\tName: %#v,\n", t.Name)
+			fmt.Fprintln(w, "},")
+		case db.Path:
+			fmt.Fprintln(w, "db.Path{")
+			fmt.Fprintf(w, "\tPath: %#v,\n", t.Path)
+			fmt.Fprintf(w, "\tMode: %#o,\n", t.Mode)
+			fmt.Fprintf(w, "\tSlices: %#v,\n", t.Slices)
+			if t.SHA256 != nil {
+				fmt.Fprint(w, "\tSHA256: &[...]byte{")
+				for i, b := range t.SHA256 {
+					if i%8 == 0 {
+						fmt.Fprint(w, "\n\t\t")
+					} else {
+						fmt.Fprint(w, " ")
+					}
+					fmt.Fprintf(w, "%#02x,", b)
+				}
+				fmt.Fprintln(w, "\n\t},")
+			}
+			if t.FinalSHA256 != nil {
+				fmt.Fprint(w, "\tFinalSHA256: &[...]byte{")
+				for i, b := range t.FinalSHA256 {
+					if i%8 == 0 {
+						fmt.Fprint(w, "\n\t\t")
+					} else {
+						fmt.Fprint(w, " ")
+					}
+					fmt.Fprintf(w, "%#02x,", b)
+				}
+				fmt.Fprintln(w, "\n\t},")
+			}
+			if t.Size != 0 {
+				fmt.Fprintf(w, "\tSize: %d,\n", t.Size)
+			}
+			if t.Link != "" {
+				fmt.Fprintf(w, "\tLink: %#v,\n", t.Link)
+			}
+			fmt.Fprintln(w, "},")
+		case db.Content:
+			fmt.Fprintln(w, "db.Content{")
+			fmt.Fprintf(w, "\tSlice: %#v,\n", t.Slice)
+			fmt.Fprintf(w, "\tPath: %#v,\n", t.Path)
+			fmt.Fprintln(w, "},")
+		default:
+			panic(fmt.Sprintf("invalid DB value %#v", v))
+		}
+	}
+}
+
+//nolint:unused
+func (p *fakeDB) dump() string {
+	var buf strings.Builder
+	fmt.Fprintln(&buf, "-----BEGIN DB DUMP-----")
+	p.dumpValues(&buf)
+	fmt.Fprintln(&buf, "-----END DB DUMP-----")
+	return buf.String()
+}

--- a/internal/slicer/pathtrack.go
+++ b/internal/slicer/pathtrack.go
@@ -1,0 +1,245 @@
+package slicer
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/canonical/chisel/internal/db"
+	"github.com/canonical/chisel/internal/deb"
+	"github.com/canonical/chisel/internal/fsutil"
+	"github.com/canonical/chisel/internal/strdist"
+)
+
+type pathTracker interface {
+	// addSlicePath records that the path belongs to the slice.
+	addSlicePath(slice, path string)
+	// addSliceGlob records that paths matched by the glob belong to the
+	// slice.
+	addSliceGlob(slice, glob string)
+	// onCreate is a callback passed to deb.ExtractOptions.onData. It
+	// records checksums of paths extracted from deb packages.
+	onData(source string, size int64) (deb.ConsumeData, error)
+	// onCreate is a callback passed to deb.ExtractOptions.OnData. It
+	// records metadata of paths extracted from deb packages.
+	onCreate(source, target, link string, mode fs.FileMode) error
+	// addTarget records the target path as being non-extracted content,
+	// i.e. not originating from a deb package.
+	addTarget(target, link string, mode fs.FileMode, data []byte)
+	// markMutated marks the target path as being changed by mutation
+	// scripts.
+	markMutated(target string)
+	// removeTarget removes the target path. It should be called for paths
+	// that have "until" attribute set.
+	removeTarget(target string)
+	// updateTargets reconciles changes made since the tracking started. It
+	// must be called before writing the database with updateDB.
+	updateTargets(root string) error
+	// upadteDB calls addToDB for each recorded entry.
+	updateDB(addToDB AddToDB) error
+}
+
+type contentInfo struct {
+	size   int64
+	digest *[sha256.Size]byte
+}
+
+func computeDigest(data []byte) *[sha256.Size]byte {
+	digest := sha256.Sum256(data)
+	return &digest
+}
+
+type stringSet []string
+
+func (s stringSet) AddOne(x string) (stringSet, bool) {
+	if s == nil {
+		return []string{x}, true
+	}
+	i := sort.SearchStrings(s, x)
+	if i == len(s) {
+		s = append(s, x)
+	} else if s[i] != x {
+		s = append(s[:i], append([]string{x}, s[i:]...)...)
+	} else {
+		return s, false
+	}
+	return s, true
+}
+
+func (s stringSet) AddMany(xs ...string) stringSet {
+	for _, x := range xs {
+		s, _ = s.AddOne(x)
+	}
+	return s
+}
+
+type pathTrackCtx struct {
+	pathSlices     map[string]stringSet
+	globSlices     map[string]stringSet
+	targetToSource map[string]string
+	sourceContent  map[string]contentInfo
+	targets        map[string]*db.Path
+	mutatedTargets map[string]bool
+}
+
+var _ pathTracker = (*pathTrackCtx)(nil)
+
+func newPathTracker() pathTracker {
+	return &pathTrackCtx{
+		pathSlices:     make(map[string]stringSet),
+		globSlices:     make(map[string]stringSet),
+		targetToSource: make(map[string]string),
+		sourceContent:  make(map[string]contentInfo),
+		targets:        make(map[string]*db.Path),
+		mutatedTargets: make(map[string]bool),
+	}
+}
+
+func (ctx *pathTrackCtx) addSlicePath(slice, path string) {
+	ctx.pathSlices[path] = ctx.pathSlices[path].AddMany(slice)
+}
+
+func (ctx *pathTrackCtx) addSliceGlob(slice, glob string) {
+	ctx.globSlices[glob] = ctx.pathSlices[glob].AddMany(slice)
+}
+
+func (ctx *pathTrackCtx) onData(source string, size int64) (deb.ConsumeData, error) {
+	// XXX: We should return nil if the source matches one of the
+	// until-paths. But that would require some additional expensive
+	// tracking. Until-paths are now untracked by removeTarget() called
+	// during their removal from the output directory.
+	consume := func(reader io.Reader) error {
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+		digest := computeDigest(data)
+		ctx.sourceContent[source] = contentInfo{size, digest}
+		return nil
+	}
+	return consume, nil
+}
+
+func (ctx *pathTrackCtx) onCreate(source, target, link string, mode fs.FileMode) error {
+	info := db.Path{
+		Path: target,
+		Mode: mode,
+		Link: link,
+	}
+	ctx.targets[target] = &info
+	ctx.targetToSource[target] = source
+	return nil
+}
+
+func (ctx *pathTrackCtx) addTarget(target, link string, mode fs.FileMode, data []byte) {
+	info := db.Path{
+		Path: target,
+		Mode: mode,
+		Link: link,
+	}
+	if data != nil {
+		info.Size = int64(len(data))
+		info.SHA256 = computeDigest(data)
+	}
+	ctx.targets[target] = &info
+	// add parents
+	for parent := fsutil.SlashedPathDir(target); parent != "/"; parent = fsutil.SlashedPathDir(parent) {
+		if _, ok := ctx.targets[parent]; ok {
+			break
+		}
+		ctx.targets[parent] = &db.Path{
+			Path: parent,
+			Mode: fs.ModeDir | 0755,
+		}
+	}
+}
+
+func (ctx *pathTrackCtx) markMutated(target string) {
+	ctx.mutatedTargets[target] = true
+}
+
+func (ctx *pathTrackCtx) removeTarget(target string) {
+	delete(ctx.targets, target)
+}
+
+func (ctx *pathTrackCtx) completeTarget(info *db.Path) {
+	// keep only permission bits
+	info.Mode = info.Mode & 07777
+
+	// copy content info from OnData callbacks
+	source := ctx.targetToSource[info.Path]
+	if content, ok := ctx.sourceContent[source]; ok {
+		info.Size = content.size
+		info.SHA256 = content.digest
+	}
+
+	// assign slices
+	slices := ctx.pathSlices[info.Path]
+	for glob, globSlices := range ctx.globSlices {
+		if strdist.GlobPath(glob, info.Path) {
+			slices = slices.AddMany(globSlices...)
+		}
+	}
+
+	// assign slices to parents
+	path := info.Path
+	for len(slices) > 0 && path != "/" {
+		newSlices := []string{}
+		for _, sl := range slices {
+			if tmp, ok := stringSet(info.Slices).AddOne(sl); ok {
+				info.Slices = tmp
+				newSlices = append(newSlices, sl)
+			}
+		}
+		slices = newSlices
+		path = fsutil.SlashedPathDir(path)
+		info = ctx.targets[path]
+	}
+}
+
+// set final digest on mutated files
+func (ctx *pathTrackCtx) refreshTarget(info *db.Path, root string) error {
+	if !ctx.mutatedTargets[info.Path] || info.SHA256 != nil {
+		// not mutated or not a regular file
+		return nil
+	}
+	local := filepath.Join(root, info.Path)
+	data, err := os.ReadFile(local)
+	if err != nil {
+		return err
+	}
+	finalDigest := computeDigest(data)
+	if *finalDigest != *info.SHA256 {
+		info.FinalSHA256 = finalDigest
+	}
+	return nil
+}
+
+func (ctx *pathTrackCtx) updateTargets(root string) (err error) {
+	for _, info := range ctx.targets {
+		ctx.completeTarget(info)
+		if err = ctx.refreshTarget(info, root); err != nil {
+			break
+		}
+	}
+	return
+}
+
+func (ctx *pathTrackCtx) updateDB(addToDB AddToDB) error {
+	for _, info := range ctx.targets {
+		if err := addToDB(*info); err != nil {
+			return fmt.Errorf("cannot write path to db: %w", err)
+		}
+		for _, sl := range info.Slices {
+			content := db.Content{sl, info.Path}
+			if err := addToDB(content); err != nil {
+				return fmt.Errorf("cannot write content to db: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -109,14 +109,13 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := fsutil.SlashedPathDir(targetPath)
-				if targetDir == "" || targetDir == "/" {
-					continue
+				parent := fsutil.SlashedPathDir(targetPath)
+				for ; parent != "/"; parent = fsutil.SlashedPathDir(parent) {
+					extractPackage[parent] = append(extractPackage[parent], deb.ExtractInfo{
+						Path:     parent,
+						Optional: true,
+					})
 				}
-				extractPackage[targetDir] = append(extractPackage[targetDir], deb.ExtractInfo{
-					Path:     targetDir,
-					Optional: true,
-				})
 			}
 		}
 		if !hasCopyright {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -32,25 +32,21 @@ func Run(options *RunOptions) error {
 
 	knownPaths["/"] = true
 
+	// addKnownPath path adds path and all its directory parent paths into
+	// knownPaths set.
 	addKnownPath := func(path string) {
 		if path[0] != '/' {
 			panic("bug: tried to add relative path to known paths")
 		}
-		cleanPath := filepath.Clean(path)
-		slashPath := cleanPath
-		if path[len(path)-1] == '/' && cleanPath != "/" {
-			slashPath += "/"
-		}
+		path = fsutil.SlashedPathClean(path)
 		for {
-			if _, ok := knownPaths[slashPath]; ok {
+			if _, ok := knownPaths[path]; ok {
 				break
 			}
-			knownPaths[slashPath] = true
-			cleanPath = filepath.Dir(cleanPath)
-			if cleanPath == "/" {
+			knownPaths[path] = true
+			if path = fsutil.SlashedPathDir(path); path == "/" {
 				break
 			}
-			slashPath = cleanPath + "/"
 		}
 	}
 
@@ -113,7 +109,7 @@ func Run(options *RunOptions) error {
 					hasCopyright = true
 				}
 			} else {
-				targetDir := filepath.Dir(strings.TrimRight(targetPath, "/")) + "/"
+				targetDir := fsutil.SlashedPathDir(targetPath)
 				if targetDir == "" || targetDir == "/" {
 					continue
 				}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -11,6 +11,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/chisel/internal/archive"
+	"github.com/canonical/chisel/internal/db"
 	"github.com/canonical/chisel/internal/setup"
 	"github.com/canonical/chisel/internal/slicer"
 	"github.com/canonical/chisel/internal/testutil"
@@ -35,6 +36,7 @@ type slicerTest struct {
 	slices  []setup.SliceKey
 	hackopt func(c *C, opts *slicer.RunOptions)
 	result  map[string]string
+	db      []any
 	error   string
 }
 
@@ -103,6 +105,15 @@ var slicerTests = []slicerTest{{
 		"/etc/dir/sub/":  "dir 01777",
 		"/etc/passwd":    "file 0644 5b41362b",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Glob extraction",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -120,6 +131,15 @@ var slicerTests = []slicerTest{{
 		"/usr/bin/":      "dir 0755",
 		"/usr/bin/hello": "file 0775 eaf29575",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Create new file under extracted directory",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -136,6 +156,15 @@ var slicerTests = []slicerTest{{
 	result: map[string]string{
 		"/tmp/":    "dir 01777", // This is the magic.
 		"/tmp/new": "file 0644 5b41362b",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Create new nested file under extracted directory",
@@ -155,6 +184,15 @@ var slicerTests = []slicerTest{{
 		"/tmp/new/":    "dir 0755",
 		"/tmp/new/sub": "file 0644 5b41362b",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Create new directory under extracted directory",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -171,6 +209,15 @@ var slicerTests = []slicerTest{{
 	result: map[string]string{
 		"/tmp/":     "dir 01777", // This is the magic.
 		"/tmp/new/": "dir 0755",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Conditional architecture",
@@ -199,6 +246,15 @@ var slicerTests = []slicerTest{{
 		"/usr/bin/hello1": "file 0775 eaf29575",
 		"/usr/bin/hello3": "file 0775 eaf29575",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Script: write a file",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -216,6 +272,15 @@ var slicerTests = []slicerTest{{
 	result: map[string]string{
 		"/tmp/":      "dir 01777",
 		"/tmp/file1": "file 0644 d98cf53e",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Script: read a file",
@@ -239,6 +304,15 @@ var slicerTests = []slicerTest{{
 		"/foo/":      "dir 0755",
 		"/foo/file2": "file 0644 5b41362b",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Script: use 'until' to remove file after mutate",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -260,6 +334,15 @@ var slicerTests = []slicerTest{{
 		"/foo/":      "dir 0755",
 		"/foo/file2": "file 0644 5b41362b",
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Script: use 'until' to remove wildcard after mutate",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -276,6 +359,15 @@ var slicerTests = []slicerTest{{
 	result: map[string]string{
 		"/usr/": "dir 0755",
 		"/etc/": "dir 0755",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Script: 'until' does not remove non-empty directories",
@@ -294,6 +386,15 @@ var slicerTests = []slicerTest{{
 		"/usr/":          "dir 0755",
 		"/usr/bin/":      "dir 0755",
 		"/usr/bin/hallo": "file 0775 eaf29575",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Script: cannot write non-mutable files",
@@ -341,6 +442,18 @@ var slicerTests = []slicerTest{{
 						content.read("/usr/bin/hello")
 		`,
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice1",
+		},
+		db.Slice{
+			Name: "base-files_myslice2",
+		},
+	},
 }, {
 	summary: "Relative content root directory must not error",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -361,6 +474,15 @@ var slicerTests = []slicerTest{{
 		opts.TargetDir, err = filepath.Rel(dir, opts.TargetDir)
 		c.Assert(err, IsNil)
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Can list parent directories of normal paths",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -379,6 +501,15 @@ var slicerTests = []slicerTest{{
 						content.list("/x")
 						content.list("/x/y")
 		`,
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Cannot list unselected directory",
@@ -424,6 +555,15 @@ var slicerTests = []slicerTest{{
 						content.list("/usr/bin")
 		`,
 	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
+	},
 }, {
 	summary: "Cannot list directories not matched by glob",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -464,6 +604,25 @@ var slicerTests = []slicerTest{{
 						/etc/ssl/openssl.cnf:
 		`,
 	},
+	db: []any{
+		db.Package{
+			Name:    "copyright-symlink-libssl3",
+			Version: "1.0",
+		},
+		db.Package{
+			Name:    "copyright-symlink-openssl",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "copyright-symlink-libssl3_libs",
+		},
+		db.Slice{
+			Name: "copyright-symlink-openssl_bins",
+		},
+		db.Slice{
+			Name: "copyright-symlink-openssl_config",
+		},
+	},
 }, {
 	summary: "Can list unclean directory paths",
 	slices:  []setup.SliceKey{{"base-files", "myslice"}},
@@ -482,6 +641,15 @@ var slicerTests = []slicerTest{{
 						content.list("/x///")
 						content.list("/x/./././y")
 		`,
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Cannot read directories",
@@ -526,6 +694,15 @@ var slicerTests = []slicerTest{{
 		"/usr/":          "dir 0755",
 		"/usr/bin/":      "dir 0755",
 		"/usr/bin/hello": "file 0775 eaf29575",
+	},
+	db: []any{
+		db.Package{
+			Name:    "base-files",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "base-files_myslice",
+		},
 	},
 }, {
 	summary: "Custom archives with custom packages",
@@ -597,6 +774,22 @@ var slicerTests = []slicerTest{{
 		"/usr/share/doc/":                   "dir 0755",
 		"/usr/share/doc/electron/":          "dir 0755",
 		"/usr/share/doc/electron/copyright": "file 0644 empty",
+	},
+	db: []any{
+		db.Package{
+			Name:    "electron",
+			Version: "1.0",
+		},
+		db.Package{
+			Name:    "proton",
+			Version: "1.0",
+		},
+		db.Slice{
+			Name: "electron_mass",
+		},
+		db.Slice{
+			Name: "proton_mass",
+		},
 	},
 }}
 
@@ -710,11 +903,15 @@ func (s *S) TestRun(c *C) {
 			archives[name] = archive
 		}
 
+		var obtainedDB = &fakeDB{}
+		var expectedDB = &fakeDB{}
+
 		targetDir := c.MkDir()
 		options := slicer.RunOptions{
 			Selection: selection,
 			Archives:  archives,
 			TargetDir: targetDir,
+			AddToDB:   obtainedDB.add,
 		}
 		if test.hackopt != nil {
 			test.hackopt(c, &options)
@@ -744,5 +941,12 @@ func (s *S) TestRun(c *C) {
 			}
 			c.Assert(testutil.TreeDump(targetDir), DeepEquals, result)
 		}
+
+		//c.Log(obtainedDB.dump())
+		for _, v := range test.db {
+			err := expectedDB.add(v)
+			c.Assert(err, IsNil)
+		}
+		c.Assert(obtainedDB.values(), DeepEquals, expectedDB.values())
 	}
 }

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -113,6 +113,145 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/bin/hallo",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			Link:   "../usr/bin/hallo",
+		},
+		db.Path{
+			Path:   "/etc/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/etc/dir/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/etc/dir/sub/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/etc/passwd",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hallo",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/bin/hello",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/bin/hallo",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/etc/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/etc/dir/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/etc/dir/sub/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/etc/passwd",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hallo",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello",
+		},
 	},
 }, {
 	summary: "Glob extraction",
@@ -139,6 +278,67 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hello",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello",
+		},
 	},
 }, {
 	summary: "Create new file under extracted directory",
@@ -164,6 +364,63 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/new",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/new",
 		},
 	},
 }, {
@@ -192,6 +449,72 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/new/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/new/sub",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/new/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/new/sub",
+		},
 	},
 }, {
 	summary: "Create new directory under extracted directory",
@@ -217,6 +540,56 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/new/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/new/",
 		},
 	},
 }, {
@@ -254,6 +627,124 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/file1",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/tmp/file3",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hello1",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/bin/hello3",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/file1",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/file3",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello1",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello3",
+		},
 	},
 }, {
 	summary: "Script: write a file",
@@ -280,6 +771,63 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/file1",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/file1",
 		},
 	},
 }, {
@@ -312,6 +860,88 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/foo/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/foo/file2",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xd9, 0x8c, 0xf5, 0x3e, 0x0c, 0x8b, 0x77, 0xc1,
+				0x4a, 0x96, 0x35, 0x8d, 0x5b, 0x69, 0x58, 0x42,
+				0x25, 0xb4, 0xbb, 0x90, 0x26, 0x42, 0x3c, 0xbc,
+				0x2f, 0x7b, 0x01, 0x61, 0x89, 0x4c, 0x40, 0x2c,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/file1",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/foo/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/foo/file2",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/file1",
+		},
 	},
 }, {
 	summary: "Script: use 'until' to remove file after mutate",
@@ -342,6 +972,72 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/foo/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/foo/file2",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xd9, 0x8c, 0xf5, 0x3e, 0x0c, 0x8b, 0x77, 0xc1,
+				0x4a, 0x96, 0x35, 0x8d, 0x5b, 0x69, 0x58, 0x42,
+				0x25, 0xb4, 0xbb, 0x90, 0x26, 0x42, 0x3c, 0xbc,
+				0x2f, 0x7b, 0x01, 0x61, 0x89, 0x4c, 0x40, 0x2c,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/foo/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/foo/file2",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
 	},
 }, {
 	summary: "Script: use 'until' to remove wildcard after mutate",
@@ -367,6 +1063,51 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/etc/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/etc/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
 		},
 	},
 }, {
@@ -394,6 +1135,67 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hallo",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hallo",
 		},
 	},
 }, {
@@ -453,6 +1255,67 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice2",
 		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice1"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice1"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hello",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice1"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice1",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice1",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice1",
+			Path:  "/usr/bin/hello",
+		},
 	},
 }, {
 	summary: "Relative content root directory must not error",
@@ -482,6 +1345,63 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "base-files_myslice",
 		},
+		db.Path{
+			Path:   "/tmp/",
+			Mode:   0777,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/tmp/file1",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x5b, 0x41, 0x36, 0x2b, 0xc8, 0x2b, 0x7f, 0x3d,
+				0x56, 0xed, 0xc5, 0xa3, 0x06, 0xdb, 0x22, 0x10,
+				0x57, 0x07, 0xd0, 0x1f, 0xf4, 0x81, 0x9e, 0x26,
+				0xfa, 0xef, 0x97, 0x24, 0xa2, 0xd4, 0x06, 0xc9,
+			},
+			Size: 5,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/tmp/file1",
+		},
 	},
 }, {
 	summary: "Can list parent directories of normal paths",
@@ -509,6 +1429,90 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/a/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/a/b/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/a/b/c",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x2c, 0x26, 0xb4, 0x6b, 0x68, 0xff, 0xc6, 0x8f,
+				0xf9, 0x9b, 0x45, 0x3c, 0x1d, 0x30, 0x41, 0x34,
+				0x13, 0x42, 0x2d, 0x70, 0x64, 0x83, 0xbf, 0xa0,
+				0xf9, 0x8a, 0x5e, 0x88, 0x62, 0x66, 0xe7, 0xae,
+			},
+			Size: 3,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Path{
+			Path:   "/x/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/x/y/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/b/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/b/c",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/x/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/x/y/",
 		},
 	},
 }, {
@@ -562,6 +1566,67 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hello",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello",
 		},
 	},
 }, {
@@ -622,6 +1687,146 @@ var slicerTests = []slicerTest{{
 		db.Slice{
 			Name: "copyright-symlink-openssl_config",
 		},
+		db.Path{
+			Path:   "/etc/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-openssl_config"},
+		},
+		db.Path{
+			Path:   "/etc/ssl/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-openssl_config"},
+		},
+		db.Path{
+			Path:   "/etc/ssl/openssl.cnf",
+			Mode:   0644,
+			Slices: []string{"copyright-symlink-openssl_config"},
+			SHA256: &[...]byte{
+				0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+				0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+				0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+				0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+			},
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-libssl3_libs", "copyright-symlink-openssl_bins"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-openssl_bins"},
+		},
+		db.Path{
+			Path:   "/usr/bin/openssl",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-openssl_bins"},
+			SHA256: &[...]byte{
+				0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+				0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+				0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+				0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+			},
+		},
+		db.Path{
+			Path:   "/usr/lib/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-libssl3_libs"},
+		},
+		db.Path{
+			Path:   "/usr/lib/x86_64-linux-gnu/",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-libssl3_libs"},
+		},
+		db.Path{
+			Path:   "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+			Mode:   0755,
+			Slices: []string{"copyright-symlink-libssl3_libs"},
+			SHA256: &[...]byte{
+				0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+				0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+				0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+				0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+			},
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/copyright-symlink-libssl3/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/copyright-symlink-libssl3/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+				0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+				0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+				0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+			},
+		},
+		db.Path{
+			Path:   "/usr/share/doc/copyright-symlink-openssl/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/copyright-symlink-openssl/copyright",
+			Mode:   0777,
+			Slices: []string(nil),
+			Link:   "../libssl3/copyright",
+		},
+		db.Content{
+			Slice: "copyright-symlink-libssl3_libs",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-libssl3_libs",
+			Path:  "/usr/lib/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-libssl3_libs",
+			Path:  "/usr/lib/x86_64-linux-gnu/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-libssl3_libs",
+			Path:  "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_bins",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_bins",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_bins",
+			Path:  "/usr/bin/openssl",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_config",
+			Path:  "/etc/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_config",
+			Path:  "/etc/ssl/",
+		},
+		db.Content{
+			Slice: "copyright-symlink-openssl_config",
+			Path:  "/etc/ssl/openssl.cnf",
+		},
 	},
 }, {
 	summary: "Can list unclean directory paths",
@@ -649,6 +1854,90 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/a/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/a/b/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/a/b/c",
+			Mode:   0644,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0x2c, 0x26, 0xb4, 0x6b, 0x68, 0xff, 0xc6, 0x8f,
+				0xf9, 0x9b, 0x45, 0x3c, 0x1d, 0x30, 0x41, 0x34,
+				0x13, 0x42, 0x2d, 0x70, 0x64, 0x83, 0xbf, 0xa0,
+				0xf9, 0x8a, 0x5e, 0x88, 0x62, 0x66, 0xe7, 0xae,
+			},
+			Size: 3,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Path{
+			Path:   "/x/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/x/y/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/b/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/a/b/c",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/x/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/x/y/",
 		},
 	},
 }, {
@@ -702,6 +1991,67 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "base-files_myslice",
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/",
+			Mode:   0755,
+			Slices: []string{"base-files_myslice"},
+		},
+		db.Path{
+			Path:   "/usr/bin/hello",
+			Mode:   0775,
+			Slices: []string{"base-files_myslice"},
+			SHA256: &[...]byte{
+				0xea, 0xf2, 0x95, 0x75, 0x43, 0x07, 0x7e, 0x93,
+				0x01, 0x5b, 0x0b, 0x2e, 0x06, 0xeb, 0xe3, 0x20,
+				0xed, 0x56, 0x8e, 0xf8, 0x53, 0x24, 0x5c, 0x7e,
+				0xbe, 0xdf, 0x33, 0xc4, 0xe4, 0x5c, 0xf4, 0x0d,
+			},
+			Size: 29,
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/base-files/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xcd, 0xb5, 0x46, 0x1d, 0x85, 0x15, 0x00, 0x2d,
+				0x0f, 0xe3, 0xba, 0xbb, 0x76, 0x4e, 0xec, 0x38,
+				0x77, 0x45, 0x8b, 0x20, 0xf4, 0xe4, 0xbb, 0x16,
+				0x21, 0x9f, 0x62, 0xea, 0x95, 0x3a, 0xfe, 0xea,
+			},
+			Size: 1228,
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/",
+		},
+		db.Content{
+			Slice: "base-files_myslice",
+			Path:  "/usr/bin/hello",
 		},
 	},
 }, {
@@ -789,6 +2139,82 @@ var slicerTests = []slicerTest{{
 		},
 		db.Slice{
 			Name: "proton_mass",
+		},
+		db.Path{
+			Path:   "/mass/",
+			Mode:   0755,
+			Slices: []string{"electron_mass", "proton_mass"},
+		},
+		db.Path{
+			Path:   "/mass/electron",
+			Mode:   0644,
+			Slices: []string{"electron_mass"},
+			SHA256: &[...]byte{
+				0xa1, 0x25, 0x8e, 0x30, 0x83, 0xf9, 0xa2, 0xd9,
+				0x94, 0xc5, 0x0d, 0xea, 0x22, 0xf3, 0xaf, 0x9e,
+				0xaa, 0x32, 0x39, 0x6b, 0x37, 0xba, 0xb6, 0x15,
+				0x2b, 0x00, 0xd5, 0x04, 0x9e, 0x76, 0x75, 0x16,
+			},
+			Size: 22,
+		},
+		db.Path{
+			Path:   "/mass/proton",
+			Mode:   0644,
+			Slices: []string{"proton_mass"},
+			SHA256: &[...]byte{
+				0xa2, 0x39, 0x0d, 0x10, 0x58, 0x70, 0xf8, 0xe0,
+				0xd8, 0xa6, 0x04, 0x60, 0xf8, 0x5d, 0x3f, 0x49,
+				0x3a, 0x11, 0xe3, 0xcc, 0xec, 0xff, 0xef, 0x06,
+				0x51, 0xbb, 0x60, 0xfb, 0xc9, 0x36, 0xc7, 0x66,
+			},
+			Size: 23,
+		},
+		db.Path{
+			Path:   "/usr/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/electron/",
+			Mode:   0755,
+			Slices: []string(nil),
+		},
+		db.Path{
+			Path:   "/usr/share/doc/electron/copyright",
+			Mode:   0644,
+			Slices: []string(nil),
+			SHA256: &[...]byte{
+				0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+				0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+				0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+				0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+			},
+		},
+		db.Content{
+			Slice: "electron_mass",
+			Path:  "/mass/",
+		},
+		db.Content{
+			Slice: "electron_mass",
+			Path:  "/mass/electron",
+		},
+		db.Content{
+			Slice: "proton_mass",
+			Path:  "/mass/",
+		},
+		db.Content{
+			Slice: "proton_mass",
+			Path:  "/mass/proton",
 		},
 	},
 }}

--- a/internal/slicer/stringset_test.go
+++ b/internal/slicer/stringset_test.go
@@ -1,0 +1,58 @@
+package slicer_test
+
+import (
+	"github.com/canonical/chisel/internal/slicer"
+	. "gopkg.in/check.v1"
+)
+
+type stringStortedSetAddOneTest struct {
+	set    slicer.StringSet
+	add    string
+	added  bool
+	result slicer.StringSet
+}
+
+var stringStortedSetAddOneTests = []stringStortedSetAddOneTest{
+	{[]string{"a", "b", "c"}, "", true, []string{"", "a", "b", "c"}},
+	{[]string{"a", "b", "c"}, "a", false, []string{"a", "b", "c"}},
+	{[]string{"b", "d"}, "a", true, []string{"a", "b", "d"}},
+	{[]string{"b", "d"}, "c", true, []string{"b", "c", "d"}},
+	{[]string{"b", "d"}, "e", true, []string{"b", "d", "e"}},
+	{[]string{"a", "b", "b", "c"}, "b", false, []string{"a", "b", "b", "c"}},
+	{[]string{}, "a", true, []string{"a"}},
+	{nil, "a", true, []string{"a"}},
+}
+
+func (s *S) TestStringAddOne(c *C) {
+	for _, test := range stringStortedSetAddOneTests {
+		result, added := test.set.AddOne(test.add)
+		c.Assert(result, DeepEquals, test.result)
+		c.Assert(added, DeepEquals, test.added)
+	}
+}
+
+type stringStortedSetAddManyTest struct {
+	set    slicer.StringSet
+	add    []string
+	result slicer.StringSet
+}
+
+var stringStortedSetAddManyTests = []stringStortedSetAddManyTest{
+	{[]string{"b", "d"}, []string{}, []string{"b", "d"}},
+	{[]string{"b", "d"}, nil, []string{"b", "d"}},
+	{[]string{}, []string{}, []string{}},
+	{nil, []string{}, nil},
+	{nil, nil, nil},
+	{[]string{}, []string{"a", "b"}, []string{"a", "b"}},
+	{nil, []string{"a", "b"}, []string{"a", "b"}},
+	{[]string{"b", "d"}, []string{"c", "a"}, []string{"a", "b", "c", "d"}},
+	{[]string{"b", "d"}, []string{"c", "c"}, []string{"b", "c", "d"}},
+	{[]string{"b", "d"}, []string{"b", "a", "b"}, []string{"a", "b", "d"}},
+}
+
+func (s *S) TestStringAddMany(c *C) {
+	for _, test := range stringStortedSetAddManyTests {
+		result := test.set.AddMany(test.add...)
+		c.Assert(result, DeepEquals, test.result)
+	}
+}


### PR DESCRIPTION
This commit completes the Chisel DB implementation by recording path
values in the DB.

Recording paths is trickier because

  1. we don't know which paths to record until all packages are sliced
     because of glob patterns,
  2. we need to record paths to slices relationship even for implicitly
     created parent directories, and
  3. we want to compute digests only once for source paths with multiple
     target paths.

This commit introduces the pathTracker interface and implementation that
tackles the problems above. Its methods are called in various places in
slicer and as callbacks in deb/extract to update the state of tracked
paths. At a high level, these are the steps taken to track paths:

  1. The callback interface in deb/extract is utilized to track created
     paths, their attributes, and their content digests.
  2. The same information is tracked for non-extracted content paths.
  3. Until-paths are untracked.
  4. Slices are assigned to both requested paths and their implicit
     parent directories.
  5. Digests of mutated files are updated.

After that, the tracked paths are recorded in the DB.

Subjective performance impact is minimal.

Note that copyright files are not owned by any slice. It is a bug that
will be fixed in future commits. That's why the nil Slices attribute was
kept in expected DB objects in test cases.