### PR TITLE
lib/sortedset: Add string sorted set

### DIFF
--- a/internal/lib/sortedset/sortedset.go
+++ b/internal/lib/sortedset/sortedset.go
@@ -1,0 +1,27 @@
+package sortedset
+
+import "sort"
+
+type String []string
+
+func (s String) AddOne(x string) (String, bool) {
+	if s == nil {
+		return []string{x}, true
+	}
+	i := sort.SearchStrings(s, x)
+	if i == len(s) {
+		s = append(s, x)
+	} else if s[i] != x {
+		s = append(s[:i], append([]string{x}, s[i:]...)...)
+	} else {
+		return s, false
+	}
+	return s, true
+}
+
+func (s String) AddMany(xs ...string) String {
+	for _, x := range xs {
+		s, _ = s.AddOne(x)
+	}
+	return s
+}

--- a/internal/lib/sortedset/sortedset_test.go
+++ b/internal/lib/sortedset/sortedset_test.go
@@ -1,0 +1,58 @@
+package sortedset_test
+
+import (
+	"github.com/canonical/chisel/internal/lib/sortedset"
+	. "gopkg.in/check.v1"
+)
+
+type stringStortedSetAddOneTest struct {
+	set    sortedset.String
+	add    string
+	added  bool
+	result sortedset.String
+}
+
+var stringStortedSetAddOneTests = []stringStortedSetAddOneTest{
+	{[]string{"a", "b", "c"}, "", true, []string{"", "a", "b", "c"}},
+	{[]string{"a", "b", "c"}, "a", false, []string{"a", "b", "c"}},
+	{[]string{"b", "d"}, "a", true, []string{"a", "b", "d"}},
+	{[]string{"b", "d"}, "c", true, []string{"b", "c", "d"}},
+	{[]string{"b", "d"}, "e", true, []string{"b", "d", "e"}},
+	{[]string{"a", "b", "b", "c"}, "b", false, []string{"a", "b", "b", "c"}},
+	{[]string{}, "a", true, []string{"a"}},
+	{nil, "a", true, []string{"a"}},
+}
+
+func (s *S) TestStringAddOne(c *C) {
+	for _, test := range stringStortedSetAddOneTests {
+		result, added := test.set.AddOne(test.add)
+		c.Assert(result, DeepEquals, test.result)
+		c.Assert(added, DeepEquals, test.added)
+	}
+}
+
+type stringStortedSetAddManyTest struct {
+	set    sortedset.String
+	add    []string
+	result sortedset.String
+}
+
+var stringStortedSetAddManyTests = []stringStortedSetAddManyTest{
+	{[]string{"b", "d"}, []string{}, []string{"b", "d"}},
+	{[]string{"b", "d"}, nil, []string{"b", "d"}},
+	{[]string{}, []string{}, []string{}},
+	{nil, []string{}, nil},
+	{nil, nil, nil},
+	{[]string{}, []string{"a", "b"}, []string{"a", "b"}},
+	{nil, []string{"a", "b"}, []string{"a", "b"}},
+	{[]string{"b", "d"}, []string{"c", "a"}, []string{"a", "b", "c", "d"}},
+	{[]string{"b", "d"}, []string{"c", "c"}, []string{"b", "c", "d"}},
+	{[]string{"b", "d"}, []string{"b", "a", "b"}, []string{"a", "b", "d"}},
+}
+
+func (s *S) TestStringAddMany(c *C) {
+	for _, test := range stringStortedSetAddManyTests {
+		result := test.set.AddMany(test.add...)
+		c.Assert(result, DeepEquals, test.result)
+	}
+}

--- a/internal/lib/sortedset/suite_test.go
+++ b/internal/lib/sortedset/suite_test.go
@@ -1,0 +1,15 @@
+package sortedset_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type S struct{}
+
+var _ = Suite(&S{})


### PR DESCRIPTION
Often we have a set of strings consisting of just one or only a few
elements. In the paths to slices relationship there's usually just one
slice owning a path. Similarly, in package source paths to extract
target paths relationship, there's usually just one target path for each
source path. But this is not always. E.g. /usr/ directory may be owned
by several slices. And /usr/bin/foo may be copied to /usr/bin/foo and
/bin/foo. It'd be wasteful to record such small sets as map[string]bool.

This commits adds sortedset package which currently contains only the
string sorted set. It's used in forthcoming commits to record paths to
slices relationship in the final Chisel DB implementation.

The package sortedset was placed under internal/lib/ directory which
seemed like a good place to shove such code which would not deserve a
box in a chisel architecture diagram.