### PR TITLE
testutil/pkgdata: Handle empty names in MakeDeb()

### DIFF
--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/base64"
+	"strings"
 	"time"
 
 	"github.com/blakesmith/ar"
@@ -174,7 +175,7 @@ func fixupTarEntry(entry *TarEntry) {
 	if hdr.Typeflag == 0 {
 		if hdr.Linkname != "" {
 			hdr.Typeflag = tar.TypeSymlink
-		} else if hdr.Name[len(hdr.Name)-1] == '/' {
+		} else if strings.HasSuffix(hdr.Name, "/") {
 			hdr.Typeflag = tar.TypeDir
 		} else {
 			hdr.Typeflag = tar.TypeReg

--- a/internal/testutil/pkgdata_test.go
+++ b/internal/testutil/pkgdata_test.go
@@ -315,6 +315,21 @@ var pkgdataCheckEntries = []checkTarEntry{{
 		ModTime:  epochStartTime,
 		Format:   tar.FormatGNU,
 	},
+}, {
+	testutil.TarEntry{
+		Header: tar.Header{
+			Name: "",
+		},
+	},
+	tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "",
+		Mode:     00644,
+		Uname:    "root",
+		Gname:    "root",
+		ModTime:  epochStartTime,
+		Format:   tar.FormatGNU,
+	},
 }}
 
 func (s *pkgdataSuite) TestMakeDeb(c *C) {


### PR DESCRIPTION
MakeDeb() now expects that all provided tar entries have a non-empty
name. Otherwise it panics on array out of bounds access. Fix it.

We can create tarballs containing entries with empty name just fine. It
makes GNU tar fail when extracting, but it fails gracefully with

  tar: Substituting `.' for empty member name
  -rw-r--r-- root/root         0 1970-01-01 01:00
  tar: .: Cannot open: File exists
  tar: Exiting with failure status due to previous errors