### PR TITLE
pkgdata: Add TarEntry shorthand constructors

### DIFF
--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -265,3 +265,35 @@ func MakeDeb(entries []TarEntry) ([]byte, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+func REG(mode int64, path, content string) TarEntry {
+	return TarEntry{
+		Header: tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     path,
+			Mode:     mode,
+		},
+		Content: []byte(content),
+	}
+}
+
+func DIR(mode int64, path string) TarEntry {
+	return TarEntry{
+		Header: tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     path,
+			Mode:     mode,
+		},
+	}
+}
+
+func LNK(mode int64, path, target string) TarEntry {
+	return TarEntry{
+		Header: tar.Header{
+			Typeflag: tar.TypeSymlink,
+			Name:     path,
+			Mode:     mode,
+			Linkname: target,
+		},
+	}
+}

--- a/internal/testutil/pkgdata_test.go
+++ b/internal/testutil/pkgdata_test.go
@@ -370,3 +370,42 @@ func (s *pkgdataSuite) TestMakeDeb(c *C) {
 	_, err = arReader.Next()
 	c.Assert(err, Equals, io.EOF)
 }
+
+func (s *S) TestTarEntryShortHands(c *C) {
+	var testCases = []struct {
+		shorthand testutil.TarEntry
+		result    testutil.TarEntry
+	}{{
+		testutil.REG(0600, "./document.txt", "cats are best"),
+		testutil.TarEntry{
+			Header: tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     "./document.txt",
+				Mode:     0600,
+			},
+			Content: []byte("cats are best"),
+		},
+	}, {
+		testutil.DIR(0755, "./home/user"),
+		testutil.TarEntry{
+			Header: tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     "./home/user",
+				Mode:     0755,
+			},
+		},
+	}, {
+		testutil.LNK(0755, "./lib", "./usr/lib/"),
+		testutil.TarEntry{
+			Header: tar.Header{
+				Typeflag: tar.TypeSymlink,
+				Name:     "./lib",
+				Mode:     0755,
+				Linkname: "./usr/lib/",
+			},
+		},
+	}}
+	for _, test := range testCases {
+		c.Assert(test.shorthand, DeepEquals, test.result)
+	}
+}


### PR DESCRIPTION
Introduce shorthand constructors for testutil.TarEntry structures. These
are REG(), DIR() and LNK() functions.

The rationale for this addition is to make the test case definition less
verbose. There are other changes in the queue that construct custom
packages to test various test cases. In all these new tests (and old
ones as well) we only care about file's type, path, mode and content.
With these shorthand constructors and function aliases we can define tar
entries like:

	DIR(0755, "./data/"),
	REG(0600, "./data/document.txt", "words words words"),
	LNK(0777, "./data/document", "document.txt"),

Instead of:

	testutil.TarEntry{
		Header: tar.Header{
			Name: "./data/",
			Mode: 0755,
		},
	},
	testutil.TarEntry{
		Header: tar.Header{
			Name: "./document.txt",
			Mode: 0600,
		},
		Content: []byte("words words words"),
	},
	testutil.TarEntry{
		Header: tar.Header{
			Name:     "./document.txt",
			Mode:     0777,
			Linkname: "document.txt",
		},
	},

The reason for the 3 letter names and the order of arguments is to make
the list of paths aligned on the same column in tarball definitions.

These function only create barebone TarEntry. It'll still get adjusted
when passed through fixupTarEntry().