### PR TITLE
testutil: Add MakeTestDeb()

### DIFF
--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -265,3 +265,11 @@ func MakeDeb(entries []TarEntry) ([]byte, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+func MakeTestDeb(entries []TarEntry) []byte {
+	data, err := MakeDeb(entries)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/testutil/pkgdata_test.go
+++ b/internal/testutil/pkgdata_test.go
@@ -370,3 +370,15 @@ func (s *pkgdataSuite) TestMakeDeb(c *C) {
 	_, err = arReader.Next()
 	c.Assert(err, Equals, io.EOF)
 }
+
+func (s *S) TestMakeTestDeb(c *C) {
+	defer func() {
+		err := recover()
+		c.Assert(err, ErrorMatches, `.*: cannot encode header: invalid PAX record: "path = \\x00./foo.*`)
+	}()
+	testutil.MakeTestDeb([]testutil.TarEntry{{
+		Header: tar.Header{
+			Name: "\000./foo",
+		},
+	}})
+}


### PR DESCRIPTION
Add MakeTestDeb() function to testutil/pkgdata. This function is just
like MakeDeb() except that it doesn't return an error. Instead, it
panics on errors.

This is useful in tests where package data is created in top-level test
case structures where we don't need to handle the error, e.g.:

	var testCases = []TestCase{{
		pkg: MakeTestDeb([]TarEntry{
			...
		}),
	}, {
		...
	}}