### PR TITLE
chore: promote "riscv64" snap to candidate on release

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64, armhf, ppc64el, s390x]
+        arch: [amd64, arm64, armhf, ppc64el, s390x, riscv64]
     env:
       TRACK: latest
       DEFAULT_RISK: edge


### PR DESCRIPTION
In #94, the workflow for promoting snaps from latest/edge to latest/candidate upon GitHub release was introduced. We didn't have riscv64 builds for the snap back then. We have it now. [1]

This PR extends the promotion workflow for the riscv64 architecture.

References:
- [1] https://answers.launchpad.net/launchpad/+question/707699