### PR TITLE
Switch from kinetic to focal in spread tests

### DIFF
--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -2,7 +2,6 @@ summary: Ensure multiple slices (with mutation scripts) are properly installed
 
 environment:
     RELEASE/jammy: 22.04
-    RELEASE/kinetic: 22.10
 
 execute: |
   rootfs_folder=rootfs_${RELEASE}

--- a/tests/use-a-custom-chisel-release/task.yaml
+++ b/tests/use-a-custom-chisel-release/task.yaml
@@ -2,7 +2,6 @@ summary: Use a custom Chisel release
 
 environment:
     RELEASE/jammy: 22.04
-    RELEASE/kinetic: 22.10
 
 execute: |
   rootfs_folder=rootfs_${RELEASE}


### PR DESCRIPTION
Kinetic is EOL and its archive is gone and the tests fail. Drop it from
spread tests.