### PR TITLE
make Spread tests run for multiple chisel-releases

### DIFF
--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -30,6 +30,3 @@ execute: |
   test -f ${rootfs_folder}/usr/lib/*-linux-*/libssl.so.*
   test -f ${rootfs_folder}/etc/ld.so.conf.d/*-linux-*.conf
   test -f ${rootfs_folder}/lib/*-linux-*/libc.so.*
-
-  # and openssl actually works
-  ${rootfs_folder}/usr/bin/openssl

--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -2,6 +2,9 @@ summary: Ensure multiple slices (with mutation scripts) are properly installed
 
 environment:
     RELEASE/jammy: 22.04
+    RELEASE/focal: 20.04
+    RELEASE/mantic: 23.10
+    RELEASE/noble: 24.04
 
 execute: |
   rootfs_folder=rootfs_${RELEASE}

--- a/tests/use-a-custom-chisel-release/task.yaml
+++ b/tests/use-a-custom-chisel-release/task.yaml
@@ -2,6 +2,9 @@ summary: Use a custom Chisel release
 
 environment:
     RELEASE/jammy: 22.04
+    RELEASE/focal: 20.04
+    RELEASE/mantic: 23.10
+    RELEASE/noble: 24.04
 
 execute: |
   rootfs_folder=rootfs_${RELEASE}


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Up to now, the Spread tests were only running for the ubuntu-22.04 chisel release. 
This PR extends the spread variants, for each spread task, such that the tests run on all supported chisel releases