### PR TITLE
fix: package names can be of length two

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -242,9 +242,14 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	return order, nil
 }
 
-var fnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){2,})\.yaml$`)
+// fnameExp matches the slice definition file basename.
+var fnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})\.yaml$`)
+
+// snameExp matches only the slice name, without the leading package name.
 var snameExp = regexp.MustCompile(`^([a-z](?:-?[a-z0-9]){2,})$`)
-var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){2,})_([a-z](?:-?[a-z0-9]){2,})$`)
+
+// knameExp matches the slice full name in pkg_slice format.
+var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})_([a-z](?:-?[a-z0-9]){2,})$`)
 
 func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	match := knameExp.FindStringSubmatch(sliceKey)
@@ -291,7 +296,7 @@ func readSlices(release *Release, baseDir, dirName string) error {
 		}
 		match := fnameExp.FindStringSubmatch(entry.Name())
 		if match == nil {
-			return fmt.Errorf("invalid slice definition filename: %q\")", entry.Name())
+			return fmt.Errorf("invalid slice definition filename: %q", entry.Name())
 		}
 
 		pkgName := match[1]

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -242,17 +242,14 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	return order, nil
 }
 
-var pkgNameExpStr = `([a-z0-9](?:-?[.a-z0-9+]){1,})`
-var sliceNameExpStr = `([a-z](?:-?[a-z0-9]){2,})`
-
 // fnameExp matches the slice definition file basename.
-var fnameExp = regexp.MustCompile(`^` + pkgNameExpStr + `\.yaml$`)
+var fnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})\.yaml$`)
 
 // snameExp matches only the slice name, without the leading package name.
-var snameExp = regexp.MustCompile(`^` + sliceNameExpStr + `$`)
+var snameExp = regexp.MustCompile(`^([a-z](?:-?[a-z0-9]){2,})$`)
 
 // knameExp matches the slice full name in pkg_slice format.
-var knameExp = regexp.MustCompile(`^` + pkgNameExpStr + `_` + sliceNameExpStr + `$`)
+var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})_([a-z](?:-?[a-z0-9]){2,})$`)
 
 func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	match := knameExp.FindStringSubmatch(sliceKey)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -242,14 +242,17 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	return order, nil
 }
 
+var pkgNameExpStr = `([a-z0-9](?:-?[.a-z0-9+]){1,})`
+var sliceNameExpStr = `([a-z](?:-?[a-z0-9]){2,})`
+
 // fnameExp matches the slice definition file basename.
-var fnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})\.yaml$`)
+var fnameExp = regexp.MustCompile(`^` + pkgNameExpStr + `\.yaml$`)
 
 // snameExp matches only the slice name, without the leading package name.
-var snameExp = regexp.MustCompile(`^([a-z](?:-?[a-z0-9]){2,})$`)
+var snameExp = regexp.MustCompile(`^` + sliceNameExpStr + `$`)
 
 // knameExp matches the slice full name in pkg_slice format.
-var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})_([a-z](?:-?[a-z0-9]){2,})$`)
+var knameExp = regexp.MustCompile(`^` + pkgNameExpStr + `_` + sliceNameExpStr + `$`)
 
 func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	match := knameExp.FindStringSubmatch(sliceKey)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1150,7 +1150,7 @@ func runParseReleaseTests(c *C, tests []setupTest) {
 	}
 }
 
-var sliceKeyTests = []struct{
+var sliceKeyTests = []struct {
 	input    string
 	expected setup.SliceKey
 	err      string

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1194,8 +1194,8 @@ var sliceKeyTests = []struct {
 	input: "1234_789",
 	err:   `invalid slice reference: "1234_789"`,
 }, {
-	input: "chicken_bar.b.q",
-	err:   `invalid slice reference: "chicken_bar.b.q"`,
+	input: "foo_bar.x.y",
+	err:   `invalid slice reference: "foo_bar.x.y"`,
 }, {
 	input: "foo-_-bar",
 	err:   `invalid slice reference: "foo-_-bar"`,

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1161,26 +1161,41 @@ var sliceKeyTests = []struct {
 	input:    "fo_bar",
 	expected: setup.SliceKey{Package: "fo", Slice: "bar"},
 }, {
+	input:    "1234_bar",
+	expected: setup.SliceKey{Package: "1234", Slice: "bar"},
+}, {
+	input:    "foo1.1-2-3_bar",
+	expected: setup.SliceKey{Package: "foo1.1-2-3", Slice: "bar"},
+}, {
+	input:    "foo-pkg_dashed-slice-name",
+	expected: setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice-name"},
+}, {
+	input:    "foo+_bar",
+	expected: setup.SliceKey{Package: "foo+", Slice: "bar"},
+}, {
+	input:    "foo_slice123",
+	expected: setup.SliceKey{Package: "foo", Slice: "slice123"},
+}, {
+	input:    "g++_bins",
+	expected: setup.SliceKey{Package: "g++", Slice: "bins"},
+}, {
+	input:    "a+_bar",
+	expected: setup.SliceKey{Package: "a+", Slice: "bar"},
+}, {
+	input:    "a._bar",
+	expected: setup.SliceKey{Package: "a.", Slice: "bar"},
+}, {
 	input: "foo_ba",
 	err:   `invalid slice reference: "foo_ba"`,
 }, {
 	input: "f_bar",
 	err:   `invalid slice reference: "f_bar"`,
 }, {
-	input:    "1234_bar",
-	expected: setup.SliceKey{Package: "1234", Slice: "bar"},
-}, {
 	input: "1234_789",
 	err:   `invalid slice reference: "1234_789"`,
 }, {
-	input:    "foo1.1-2-3_bar",
-	expected: setup.SliceKey{Package: "foo1.1-2-3", Slice: "bar"},
-}, {
 	input: "chicken_bar.b.q",
 	err:   `invalid slice reference: "chicken_bar.b.q"`,
-}, {
-	input:    "foo-pkg_dashed-slice-name",
-	expected: setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice-name"},
 }, {
 	input: "foo-_-bar",
 	err:   `invalid slice reference: "foo-_-bar"`,
@@ -1194,32 +1209,17 @@ var sliceKeyTests = []struct {
 	input: "-foo_bar",
 	err:   `invalid slice reference: "-foo_bar"`,
 }, {
-	input:    "foo+_bar",
-	expected: setup.SliceKey{Package: "foo+", Slice: "bar"},
-}, {
-	input:    "foo_slice123",
-	expected: setup.SliceKey{Package: "foo", Slice: "slice123"},
-}, {
 	input: "foo_bar_baz",
 	err:   `invalid slice reference: "foo_bar_baz"`,
-}, {
-	input:    "g++_bins",
-	expected: setup.SliceKey{Package: "g++", Slice: "bins"},
-}, {
-	input:    "a+_bar",
-	expected: setup.SliceKey{Package: "a+", Slice: "bar"},
 }, {
 	input: "a-_bar",
 	err:   `invalid slice reference: "a-_bar"`,
 }, {
-	input:    "a._bar",
-	expected: setup.SliceKey{Package: "a.", Slice: "bar"},
-}, {
 	input: "+++_bar",
-	err:   `invalid slice reference: .*`,
+	err:   `invalid slice reference: "\+\+\+_bar"`,
 }, {
 	input: "..._bar",
-	err:   `invalid slice reference: .*`,
+	err:   `invalid slice reference: "\.\.\._bar"`,
 }, {
 	input: "white space_no-whitespace",
 	err:   `invalid slice reference: "white space_no-whitespace"`,

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1194,6 +1194,9 @@ var sliceKeyTests = []struct {
 	input: "-foo_bar",
 	err:   `invalid slice reference: "-foo_bar"`,
 }, {
+	input: "foo+_bar",
+	expected: setup.SliceKey{Package: "foo+", Slice: "bar"},
+}, {
 	input:    "foo_slice123",
 	expected: setup.SliceKey{Package: "foo", Slice: "slice123"},
 }}
@@ -1201,7 +1204,7 @@ var sliceKeyTests = []struct {
 func (s *S) TestParseSliceKey(c *C) {
 	for _, test := range sliceKeyTests {
 		key, err := setup.ParseSliceKey(test.input)
-		if err != nil || test.err != "" {
+		if test.err != "" {
 			c.Assert(err, ErrorMatches, test.err)
 			continue
 		}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1150,13 +1150,11 @@ func runParseReleaseTests(c *C, tests []setupTest) {
 	}
 }
 
-type sliceKeyTest struct {
+var sliceKeyTests = []struct{
 	input    string
 	expected setup.SliceKey
 	err      string
-}
-
-var sliceKeyTests = []sliceKeyTest{{
+}{{
 	input:    "foo_bar",
 	expected: setup.SliceKey{Package: "foo", Slice: "bar"},
 }, {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1199,6 +1199,30 @@ var sliceKeyTests = []struct {
 }, {
 	input:    "foo_slice123",
 	expected: setup.SliceKey{Package: "foo", Slice: "slice123"},
+}, {
+	input: "foo_bar_baz",
+	err:   `invalid slice reference: "foo_bar_baz"`,
+}, {
+	input:    "g++_bins",
+	expected: setup.SliceKey{Package: "g++", Slice: "bins"},
+}, {
+	input:    "a+_bar",
+	expected: setup.SliceKey{Package: "a+", Slice: "bar"},
+}, {
+	input: "a-_bar",
+	err:   `invalid slice reference: "a-_bar"`,
+}, {
+	input:    "a._bar",
+	expected: setup.SliceKey{Package: "a.", Slice: "bar"},
+}, {
+	input: "+++_bar",
+	err:   `invalid slice reference: .*`,
+}, {
+	input: "..._bar",
+	err:   `invalid slice reference: .*`,
+}, {
+	input: "white space_no-whitespace",
+	err:   `invalid slice reference: "white space_no-whitespace"`,
 }}
 
 func (s *S) TestParseSliceKey(c *C) {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1194,7 +1194,7 @@ var sliceKeyTests = []struct {
 	input: "-foo_bar",
 	err:   `invalid slice reference: "-foo_bar"`,
 }, {
-	input: "foo+_bar",
+	input:    "foo+_bar",
 	expected: setup.SliceKey{Package: "foo+", Slice: "bar"},
 }, {
 	input:    "foo_slice123",


### PR DESCRIPTION
This PR adds support for package names with a minimum length of two. Previously chisel only supported a minimum length of 3. The limit on the slice name is kept unchanged.

Fixes #119.
