### PR TITLE
fix(ci): adjust libc6 spread test for noble

### DIFF
--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -31,8 +31,8 @@ execute: |
   test -f ${rootfs_folder}/etc/ld.so.conf.d/*-linux-*.conf
   if [[ "${RELEASE}" == "24.04" ]]
   then
-    libc_base_path="/usr/lib/"
+    libc_base_path="/usr/lib"
   else
-    libc_base_path="/lib/"
+    libc_base_path="/lib"
   fi
-  test -f ${rootfs_folder}${libc_base_path}*-linux-*/libc.so.*
+  test -f ${rootfs_folder}${libc_base_path}/*-linux-*/libc.so.*

--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -29,4 +29,10 @@ execute: |
   test -f ${rootfs_folder}/etc/ssl/openssl.cnf
   test -f ${rootfs_folder}/usr/lib/*-linux-*/libssl.so.*
   test -f ${rootfs_folder}/etc/ld.so.conf.d/*-linux-*.conf
-  test -f ${rootfs_folder}/lib/*-linux-*/libc.so.*
+  if [[ "${RELEASE}" == "24.04" ]]
+  then
+    libc_base_path="/usr/lib/"
+  else
+    libc_base_path="/lib/"
+  fi
+  test -f ${rootfs_folder}${libc_base_path}*-linux-*/libc.so.*


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The `libc6` contents' paths have changed in 24.04.

This PR adjusts the spread tests such that they accommodate that change.

This should fix the spread test errors in PRs like #116 