### PR TITLE
chore: add noble as separate github action

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -14,11 +14,6 @@ jobs:
   spread-tests:
     name: Spread tests
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        versions: ["focal jammy mantic", "noble"]
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
 
@@ -34,4 +29,4 @@ jobs:
       - name: Build and run spread
         run: |
           (cd _spread/cmd/spread && go build)
-          _spread/cmd/spread/spread -vv ${{ matrix.versions }}
+          _spread/cmd/spread/spread -vv focal jammy mantic

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build and run spread
         run: |
           (cd _spread/cmd/spread && go build)
-          _spread/cmd/spread/spread -vv focal jammy mantic
+          _spread/cmd/spread/spread -v focal jammy mantic

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -14,6 +14,10 @@ jobs:
   spread-tests:
     name: Spread tests
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        versions: ["focal jammy mantic", "noble"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
@@ -30,4 +34,4 @@ jobs:
       - name: Build and run spread
         run: |
           (cd _spread/cmd/spread && go build)
-          _spread/cmd/spread/spread -vv
+          _spread/cmd/spread/spread -vv ${{ matrix.versions }}

--- a/spread.yaml
+++ b/spread.yaml
@@ -52,3 +52,8 @@ prepare: |
 suites:
   tests/:
     summary: Tests common scenarios
+    environment:
+        RELEASE/jammy: 22.04
+        RELEASE/focal: 20.04
+        RELEASE/mantic: 23.10
+        RELEASE/noble: 24.04

--- a/tests/basic/task.yaml
+++ b/tests/basic/task.yaml
@@ -1,11 +1,5 @@
 summary: Ensure multiple slices (with mutation scripts) are properly installed
 
-environment:
-    RELEASE/jammy: 22.04
-    RELEASE/focal: 20.04
-    RELEASE/mantic: 23.10
-    RELEASE/noble: 24.04
-
 execute: |
   rootfs_folder=rootfs_${RELEASE}
   mkdir -p $rootfs_folder

--- a/tests/use-a-custom-chisel-release/task.yaml
+++ b/tests/use-a-custom-chisel-release/task.yaml
@@ -1,11 +1,5 @@
 summary: Use a custom Chisel release
 
-environment:
-    RELEASE/jammy: 22.04
-    RELEASE/focal: 20.04
-    RELEASE/mantic: 23.10
-    RELEASE/noble: 24.04
-
 execute: |
   rootfs_folder=rootfs_${RELEASE}
   mkdir -p $rootfs_folder


### PR DESCRIPTION
Remove noble from the CI because the tests break too often. Will add them back when the release is stable.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
