### PR TITLE
feat: support for several slices of the same package

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -213,7 +213,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			if contentIsCached {
 				pathReader = bytes.NewReader(contentCache)
 			}
-			// The Mode is the same in all extractInfo for the same path.
+			// The Mode is the same in all extractInfo for the same destination path.
 			if extracts[0].Mode != 0 {
 				tarHeader.Mode = int64(extracts[0].Mode)
 			}

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -169,9 +169,8 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			continue
 		}
 
-		// We group the info in batches because we only want to extract to
-		// each destination once. For example, all globs extract to the same
-		// destination, so we can just group them together.
+		// We group the info in batches by the real path of the destination so
+		// each item is only extracted once.
 		extractInfos := map[string][]*ExtractInfo{}
 		for _, path := range extractPaths {
 			for _, extractInfo := range options.Extract[path] {
@@ -187,7 +186,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 		}
 
 		var contentCache []byte
-		var contentIsCached = len(extractInfos) > 1 && !sourceIsDir && len(extractInfos) > 1
+		var contentIsCached = len(extractInfos) > 1 && !sourceIsDir
 		if contentIsCached {
 			// Read and cache the content so it may be reused.
 			// As an alternative, to avoid having an entire file in

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -219,7 +219,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 					if mode < extractInfo.Mode {
 						mode, extractInfo.Mode = extractInfo.Mode, mode
 					}
-					return fmt.Errorf("path requested twice with diverging modes %s: %o != %o", relPath, mode, extractInfo.Mode)
+					return fmt.Errorf("path %s requested twice with diverging mode: %o != %o", relPath, mode, extractInfo.Mode)
 				}
 			}
 			if mode != 0 {

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -174,15 +174,14 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			if extractPath == "" {
 				continue
 			}
-			switch {
-			case strings.ContainsAny(extractPath, "*?"):
+			if strings.ContainsAny(extractPath, "*?") {
 				if strdist.GlobPath(extractPath, sourcePath) {
 					for _, extractInfo := range extractInfos {
 						extractInfosByPath[sourcePath] = append(extractInfosByPath[sourcePath], extractInfo)
 					}
 					delete(pendingPaths, extractPath)
 				}
-			case extractPath == sourcePath:
+			} else if extractPath == sourcePath {
 				for _, extractInfo := range extractInfos {
 					extractInfosByPath[extractInfo.Path] = append(extractInfosByPath[extractInfo.Path], extractInfo)
 				}

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -275,9 +275,8 @@ func parentDirs(path string) []string {
 	return parents
 }
 
-// shouldExtract takes a package's entry path and a list of ExtractInfo,
-// it then returns all paths including globs of ExtractInfo(s) that match
-// pkgPath.
+// shouldExtract takes a path and a map of ExtractInfo(s), it then returns all
+// keys of the map for which the ExtractInfo matches the path.
 func shouldExtract(pkgPath string, extractInfos map[string][]ExtractInfo) (paths []string, globs []string) {
 	if pkgPath == "" {
 		return nil, nil

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -187,7 +187,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 		}
 
 		var contentCache []byte
-		var contentIsCached = len(extractInfos) > 1 && !sourceIsDir
+		var contentIsCached = len(extractInfos) > 1 && !sourceIsDir && len(extractInfos) > 1
 		if contentIsCached {
 			// Read and cache the content so it may be reused.
 			// As an alternative, to avoid having an entire file in
@@ -203,12 +203,12 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 
 		var pathReader io.Reader = tarReader
 		for relPath, extracts := range extractInfos {
-			extractInfo := extracts[0]
 			if contentIsCached {
 				pathReader = bytes.NewReader(contentCache)
 			}
-			if extractInfo.Mode != 0 {
-				tarHeader.Mode = int64(extractInfo.Mode)
+			// The Mode is the same in all extractInfo for the same path.
+			if extracts[0].Mode != 0 {
+				tarHeader.Mode = int64(extracts[0].Mode)
 			}
 			// Create the parent directories using the permissions from the tarball.
 			parents := parentDirs(relPath)
@@ -277,8 +277,8 @@ func parentDirs(path string) []string {
 }
 
 // shouldExtract takes a package's entry path and a list of ExtractInfo,
-// it then returns all paths and globs for ExtractInfo(s) that match the package
-// path.
+// it then returns all paths including globs of ExtractInfo(s) that match
+// pkgPath.
 func shouldExtract(pkgPath string, extractInfos map[string][]ExtractInfo) (paths []string, globs []string) {
 	if pkgPath == "" {
 		return nil, nil

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -157,7 +157,6 @@ var extractTests = []extractTest{{
 		"/dir/":         "dir 0755",
 		"/dir/several/": "dir 0755",
 	},
-	// TODO discuss in PR about this. I think this is something we want.
 	notCreated: []string{},
 }, {
 	summary: "Globbing for files with multiple levels at once",
@@ -352,7 +351,7 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract from package "test-package": path /dir/ requested twice with diverging mode: 777 != 0`,
+	error: `cannot extract from package "test-package": path /dir/ requested twice with diverging mode: 0777 != 0000`,
 }}
 
 func (s *S) TestExtract(c *C) {

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -157,7 +157,8 @@ var extractTests = []extractTest{{
 		"/dir/":         "dir 0755",
 		"/dir/several/": "dir 0755",
 	},
-	notCreated: []string{"/dir/"},
+	// TODO add a comment about this. I think this is something we want.
+	notCreated: []string{},
 }, {
 	summary: "Globbing for files with multiple levels at once",
 	pkgdata: testutil.PackageData["test-package"],
@@ -175,7 +176,7 @@ var extractTests = []extractTest{{
 		"/dir/several/levels/deep/":     "dir 0755",
 		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
 	},
-	notCreated: []string{"/dir/"},
+	notCreated: []string{},
 }, {
 	summary: "Globbing multiple paths",
 	pkgdata: testutil.PackageData["test-package"],
@@ -197,7 +198,7 @@ var extractTests = []extractTest{{
 		"/dir/several/levels/deep/":     "dir 0755",
 		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
 	},
-	notCreated: []string{"/dir/"},
+	notCreated: []string{},
 }, {
 	summary: "Globbing must have matching source and target",
 	pkgdata: testutil.PackageData["test-package"],
@@ -348,7 +349,7 @@ func (s *S) TestExtract(c *C) {
 		options.Package = "test-package"
 		options.TargetDir = dir
 		createdPaths := make(map[string]bool)
-		options.Create = func(_ *deb.ExtractInfo, o *fsutil.CreateOptions) error {
+		options.Create = func(_ []*deb.ExtractInfo, o *fsutil.CreateOptions) error {
 			relPath := filepath.Clean("/" + strings.TrimPrefix(o.Path, dir))
 			if o.Mode.IsDir() {
 				relPath = relPath + "/"

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -209,7 +209,7 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract .*: when using wildcards source and target paths must match: /foo/b\*\*`,
+	error: `cannot extract from package "test-package": when using wildcards source and target paths must match: /foo/b\*\*`,
 }, {
 	summary: "Globbing must also have a single target",
 	pkgdata: testutil.PackageData["test-package"],
@@ -222,7 +222,7 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract .*: when using wildcards source and target paths must match: /foo/b\*\*`,
+	error: `cannot extract from package "test-package": when using wildcards source and target paths must match: /foo/b\*\*`,
 }, {
 	summary: "Globbing cannot change modes",
 	pkgdata: testutil.PackageData["test-package"],
@@ -234,7 +234,7 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract .*: when using wildcards source and target paths must match: /dir/n\*\*`,
+	error: `cannot extract from package "test-package": when using wildcards source and target paths must match: /dir/n\*\*`,
 }, {
 	summary: "Missing file",
 	pkgdata: testutil.PackageData["test-package"],

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -157,7 +157,7 @@ var extractTests = []extractTest{{
 		"/dir/":         "dir 0755",
 		"/dir/several/": "dir 0755",
 	},
-	// TODO add a comment about this. I think this is something we want.
+	// TODO discuss in PR about this. I think this is something we want.
 	notCreated: []string{},
 }, {
 	summary: "Globbing for files with multiple levels at once",

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -338,6 +338,21 @@ var extractTests = []extractTest{{
 		"/日本/語": "file 0644 85738f8f",
 	},
 	notCreated: []string{},
+}, {
+	summary: "Entries for same destination must have the same mode",
+	pkgdata: testutil.PackageData["test-package"],
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/dir/": []deb.ExtractInfo{{
+				Path: "/dir/",
+				Mode: 0777,
+			}},
+			"/d**": []deb.ExtractInfo{{
+				Path: "/d**",
+			}},
+		},
+	},
+	error: `cannot extract from package "test-package": path requested twice with diverging modes /dir/: 777 != 0`,
 }}
 
 func (s *S) TestExtract(c *C) {
@@ -349,7 +364,7 @@ func (s *S) TestExtract(c *C) {
 		options.Package = "test-package"
 		options.TargetDir = dir
 		createdPaths := make(map[string]bool)
-		options.Create = func(_ []*deb.ExtractInfo, o *fsutil.CreateOptions) error {
+		options.Create = func(_ []deb.ExtractInfo, o *fsutil.CreateOptions) error {
 			relPath := filepath.Clean("/" + strings.TrimPrefix(o.Path, dir))
 			if o.Mode.IsDir() {
 				relPath = relPath + "/"

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -352,7 +352,7 @@ var extractTests = []extractTest{{
 			}},
 		},
 	},
-	error: `cannot extract from package "test-package": path requested twice with diverging modes /dir/: 777 != 0`,
+	error: `cannot extract from package "test-package": path /dir/ requested twice with diverging mode: 777 != 0`,
 }}
 
 func (s *S) TestExtract(c *C) {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1295,6 +1295,21 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `package "mypkg" has invalid essential slice reference: "mypkg-slice"`,
+}, {
+	summary: "Glob clashes with file with explicit mode set",
+	input: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**:
+				myslice2:
+					contents:
+						/dir/file: {text: "foo"}
+		`,
+	},
+	// TODO this should be an error because the content does not match.
 }}
 
 var defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1296,7 +1296,7 @@ var setupTests = []setupTest{{
 	},
 	relerror: `package "mypkg" has invalid essential slice reference: "mypkg-slice"`,
 }, {
-	summary: "Glob clashes with file with explicit mode set",
+	summary: "Glob clashes within same package",
 	input: map[string]string{
 		"slices/mydir/test-package.yaml": `
 			package: test-package

--- a/internal/slicer/report.go
+++ b/internal/slicer/report.go
@@ -70,3 +70,27 @@ func (r *Report) Add(slice *setup.Slice, fsEntry *fsutil.Entry) error {
 	}
 	return nil
 }
+
+type Modification func(*ReportEntry) error
+
+func AddSlice(slice *setup.Slice) Modification {
+	return func(entry *ReportEntry) error {
+		entry.Slices[slice] = true
+		return nil
+	}
+}
+
+func (r *Report) Modify(path string, f ...Modification) error {
+	entry, ok := r.Entries[path]
+	if !ok {
+		return fmt.Errorf("cannot modify path in report: %s not previously added", path)
+	}
+	for _, modify := range f {
+		err := modify(&entry)
+		if err != nil {
+			return err
+		}
+	}
+	r.Entries[path] = entry
+	return nil
+}

--- a/internal/slicer/report.go
+++ b/internal/slicer/report.go
@@ -70,27 +70,3 @@ func (r *Report) Add(slice *setup.Slice, fsEntry *fsutil.Entry) error {
 	}
 	return nil
 }
-
-type Modification func(*ReportEntry) error
-
-func AddSlice(slice *setup.Slice) Modification {
-	return func(entry *ReportEntry) error {
-		entry.Slices[slice] = true
-		return nil
-	}
-}
-
-func (r *Report) Modify(path string, f ...Modification) error {
-	entry, ok := r.Entries[path]
-	if !ok {
-		return fmt.Errorf("cannot modify path in report: %s not previously added", path)
-	}
-	for _, modify := range f {
-		err := modify(&entry)
-		if err != nil {
-			return err
-		}
-	}
-	r.Entries[path] = entry
-	return nil
-}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -353,7 +353,7 @@ func Run(options *RunOptions) (*Report, error) {
 	// Order the directories so the deepest ones appear first, this way we can
 	// check for empty directories properly.
 	sort.Slice(untilDirs, func(i, j int) bool {
-		return !(strings.Compare(untilDirs[i], untilDirs[j]) < 0)
+		return strings.Compare(untilDirs[i], untilDirs[j]) > 0
 	})
 	for _, realPath := range untilDirs {
 		err := os.Remove(realPath)

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -349,6 +350,11 @@ func Run(options *RunOptions) (*Report, error) {
 			return nil, fmt.Errorf("cannot perform 'until' removal: %w", err)
 		}
 	}
+	// Order the directories so the deepest ones appear first, this way we can
+	// check for empty directories properly.
+	sort.Slice(untilDirs, func(i, j int) bool {
+		return !(strings.Compare(untilDirs[i], untilDirs[j]) < 0)
+	})
 	for _, realPath := range untilDirs {
 		err := os.Remove(realPath)
 		// The non-empty directory error is caught by IsExist as well.

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -170,16 +170,9 @@ func Run(options *RunOptions) (*Report, error) {
 				relPath = relPath + "/"
 			}
 
-			var entry *fsutil.Entry
-			if _, ok := report.Entries[relPath]; !ok {
-				// Optimization: we only create the content once. Because
-				// of the invariants it will actually be the same if has
-				// the same destination path.
-				e, err := fsutil.Create(o)
-				if err != nil {
-					return err
-				}
-				entry = e
+			entry, err := fsutil.Create(o)
+			if err != nil {
+				return err
 			}
 			// Content created was not listed in a slice because extractInfo
 			// is empty.
@@ -206,12 +199,7 @@ func Run(options *RunOptions) (*Report, error) {
 						until = someNo
 					}
 
-					var err error
-					if entry != nil {
-						err = report.Add(s, entry)
-					} else {
-						err = report.Modify(relPath, AddSlice(s))
-					}
+					err := report.Add(s, entry)
 					if err != nil {
 						return err
 					}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -212,13 +212,8 @@ func Run(options *RunOptions) (*Report, error) {
 			if len(pathInfo.Arch) > 0 && !contains(pathInfo.Arch, arch) {
 				continue
 			}
-			if pathInfo.Kind == setup.CopyPath || pathInfo.Kind == setup.GlobPath {
+			if done[targetPath] || pathInfo.Kind == setup.CopyPath || pathInfo.Kind == setup.GlobPath {
 				continue
-			}
-			if done[targetPath] {
-				// The content created would have had the same properties. We
-				// are only adding the slice to the existing report entry.
-				report.Entries[targetPath].Slices[slice] = true
 			}
 			done[targetPath] = true
 			targetPath = filepath.Join(targetDir, targetPath)

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -187,6 +187,7 @@ func Run(options *RunOptions) (*Report, error) {
 				return nil
 			}
 			listed := false
+			globListed := false
 			until := untilPaths[relPath]
 			for _, extractInfo := range extractInfos {
 				for _, s := range pkgSlices[slice.Package] {
@@ -194,12 +195,9 @@ func Run(options *RunOptions) (*Report, error) {
 					if !ok {
 						continue
 					}
-					if !listed {
-						// Check whether the file was created because it matched a glob.
-						if strings.ContainsAny(extractInfo.Path, "*?") {
-							addKnownPath(relPath)
-						}
-						listed = true
+					listed = true
+					if strings.ContainsAny(extractInfo.Path, "*?") {
+						globListed = true
 					}
 
 					if pathInfo.Until == setup.UntilMutate && until == empty {
@@ -221,6 +219,9 @@ func Run(options *RunOptions) (*Report, error) {
 			}
 			if listed {
 				untilPaths[relPath] = until
+			}
+			if globListed {
+				addKnownPath(relPath)
 			}
 
 			return nil

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -149,13 +149,13 @@ func Run(options *RunOptions) (*Report, error) {
 		packages[slice.Package] = reader
 	}
 
-	type UntilPathStatus int
+	type untilPathStatus int
 	const (
-		empty UntilPathStatus = iota
+		empty untilPathStatus = iota
 		allYes
 		someNo
 	)
-	untilPaths := map[string]UntilPathStatus{}
+	untilPaths := map[string]untilPathStatus{}
 
 	// Creates the filesystem entry and adds it to the report.
 	create := func(extractInfos []*deb.ExtractInfo, o *fsutil.CreateOptions) error {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1113,7 +1113,7 @@ func (s *S) TestRun(c *C) {
 
 func runSlicerTests(c *C, tests []slicerTest) {
 	for _, test := range tests {
-		for _, slices := range permutations(test.slices) {
+		for _, slices := range testutil.Permutations(test.slices) {
 			c.Logf("Summary: %s", test.summary)
 
 			if _, ok := test.release["chisel.yaml"]; !ok {
@@ -1218,38 +1218,4 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 		result[entry.Path] = fmt.Sprintf("%s {%s}", fsDump, strings.Join(slicesStr, ","))
 	}
 	return result
-}
-
-func permutations[S ~[]E, E any](s S) []S {
-	var output []S
-	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm.
-	var generate func(k int, s S)
-	generate = func(k int, s S) {
-		// Copy the array before swapping elements.
-		r := make([]E, len(s))
-		copy(r, s)
-		s = r
-
-		if k == 1 {
-			output = append(output, s)
-			return
-		}
-		// Generate permutations with k-th unaltered.
-		// Initially k = length(A).
-		generate(k-1, s)
-
-		// Generate permutations for k-th swapped with each k-1 initial.
-		for i := 0; i < k-1; i += 1 {
-			// Swap choice dependent on parity of k (even or odd).
-			if k%2 == 0 {
-				s[i], s[k-1] = s[k-1], s[i]
-			} else {
-				s[0], s[k-1] = s[k-1], s[0]
-			}
-			generate(k-1, s)
-		}
-	}
-
-	generate(len(s), s)
-	return output
 }

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -794,52 +794,6 @@ var slicerTests = []slicerTest{{
 		"/other-dir/file": "symlink ../dir/file {test-package_myslice1}",
 	},
 }, {
-	summary: "Same glob in several entries, with until:mutate",
-	slices: []setup.SliceKey{
-		{"test-package", "myslice1"},
-		{"test-package", "myslice2"},
-	},
-	release: map[string]string{
-		"slices/mydir/test-package.yaml": `
-			package: test-package
-			slices:
-				myslice1:
-					contents:
-						/dir/**:
-					mutate: |
-						content.read("/dir/file")
-				myslice2:
-					contents:
-						/dir/**: {until: mutate}
-					mutate: |
-						content.read("/dir/file")
-		`,
-	},
-	filesystem: map[string]string{
-		"/dir/nested/other-file":        "file 0644 6b86b273",
-		"/dir/several/":                 "dir 0755",
-		"/dir/several/levels/":          "dir 0755",
-		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
-		"/dir/":                         "dir 0755",
-		"/dir/file":                     "file 0644 cc55e2ec",
-		"/dir/nested/":                  "dir 0755",
-		"/dir/nested/file":              "file 0644 84237a05",
-		"/dir/other-file":               "file 0644 63d5dd49",
-		"/dir/several/levels/deep/":     "dir 0755",
-	},
-	report: map[string]string{
-		"/dir/":                         "dir 0755 {test-package_myslice1,test-package_myslice2}",
-		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
-		"/dir/nested/":                  "dir 0755 {test-package_myslice1,test-package_myslice2}",
-		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1,test-package_myslice2}",
-		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1,test-package_myslice2}",
-		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1,test-package_myslice2}",
-		"/dir/several/":                 "dir 0755 {test-package_myslice1,test-package_myslice2}",
-		"/dir/several/levels/":          "dir 0755 {test-package_myslice1,test-package_myslice2}",
-		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1,test-package_myslice2}",
-		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1,test-package_myslice2}",
-	},
-}, {
 	summary: "Same glob in several entries with until:mutate and reading from script",
 	slices: []setup.SliceKey{
 		{"test-package", "myslice1"},

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1146,7 +1146,7 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 
 func permutations[S ~[]E, E any](s S) []S {
 	var output []S
-	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm
+	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm.
 	var generate func(k int, s S)
 	generate = func(k int, s S) {
 		// Copy the array before swapping elements.
@@ -1158,13 +1158,13 @@ func permutations[S ~[]E, E any](s S) []S {
 			output = append(output, s)
 			return
 		}
-		// Generate permutations with k-th unaltered
-		// Initially k = length(A)
+		// Generate permutations with k-th unaltered.
+		// Initially k = length(A).
 		generate(k-1, s)
 
-		// Generate permutations for k-th swapped with each k-1 initial
+		// Generate permutations for k-th swapped with each k-1 initial.
 		for i := 0; i < k-1; i += 1 {
-			// Swap choice dependent on parity of k (even or odd)
+			// Swap choice dependent on parity of k (even or odd).
 			if k%2 == 0 {
 				s[i], s[k-1] = s[k-1], s[i]
 			} else {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -933,7 +933,7 @@ var slicerTests = []slicerTest{{
 		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1}",
 	},
 }, {
-	summary: "Overlapping glob and single entry, until:mutate and reading from script",
+	summary: "Overlapping glob and single entry, until:mutate on entry and reading from script",
 	slices: []setup.SliceKey{
 		{"test-package", "myslice1"},
 		{"test-package", "myslice2"},
@@ -967,6 +967,82 @@ var slicerTests = []slicerTest{{
 		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
 	},
 	report: map[string]string{
+		// TODO, myslice2 should not appear in the report, this is pending PR #131.
+		"/dir/":                         "dir 0755 {test-package_myslice1}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1}",
+	},
+}, {
+	summary: "Overlapping glob and single entry, until:mutate on glob and reading from script",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice1"},
+		{"test-package", "myslice2"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/file:
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/":     "dir 0755",
+		"/dir/file": "file 0644 cc55e2ec",
+	},
+	report: map[string]string{
+		// TODO, myslice1 should not appear in the report, this is pending PR #131.
+		"/dir/":                         "dir 0755 {test-package_myslice1}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1}",
+	},
+}, {
+	summary: "Overlapping glob and single entry, until:mutate on both and reading from script",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice1"},
+		{"test-package", "myslice2"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/file: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{},
+	report: map[string]string{
+		// TODO, this should be empty, this is pending PR #131.
 		"/dir/":                         "dir 0755 {test-package_myslice1}",
 		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
 		"/dir/nested/":                  "dir 0755 {test-package_myslice1}",

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -426,7 +426,7 @@ var slicerTests = []slicerTest{{
 		// Note: This is the only case where two slices can declare the same
 		// file without conflicts.
 		// TODO which slice(s) should own the file.
-		"/textFile": "file 0644 c6c83d10 {other-package_myslice,test-package_myslice}",
+		"/textFile": "file 0644 c6c83d10 {other-package_myslice}",
 	},
 }, {
 	summary: "Script: write a file",
@@ -808,12 +808,10 @@ var slicerTests = []slicerTest{{
 						/dir/file:
 						/dir/file-copy:  {copy: /dir/file}
 						/other-dir/file: {symlink: ../dir/file}
-						/dir/text-file:  {text: data1}
 						/dir/foo/bar/:   {make: true, mode: 01777}
 				myslice2:
 					contents:
 						/dir/other-file:
-						/dir/text-file:  {text: data1}
 		`,
 	},
 	filesystem: map[string]string{
@@ -823,7 +821,6 @@ var slicerTests = []slicerTest{{
 		"/dir/foo/":       "dir 0755",
 		"/dir/foo/bar/":   "dir 01777",
 		"/dir/other-file": "file 0644 63d5dd49",
-		"/dir/text-file":  "file 0644 5b41362b",
 		"/other-dir/":     "dir 0755",
 		"/other-dir/file": "symlink ../dir/file",
 	},
@@ -832,7 +829,6 @@ var slicerTests = []slicerTest{{
 		"/dir/file-copy":  "file 0644 cc55e2ec {test-package_myslice1}",
 		"/dir/foo/bar/":   "dir 01777 {test-package_myslice1}",
 		"/dir/other-file": "file 0644 63d5dd49 {test-package_myslice2}",
-		"/dir/text-file":  "file 0644 5b41362b {test-package_myslice1,test-package_myslice2}",
 		"/other-dir/file": "symlink ../dir/file {test-package_myslice1}",
 	},
 }}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -357,44 +357,6 @@ var slicerTests = []slicerTest{{
 		"/dir/file": "file 0644 a441b15f {implicit-parent_myslice}",
 	},
 }, {
-	summary: "Install two packages, explicit path has preference over implicit parent (reverse order)",
-	slices: []setup.SliceKey{
-		{"explicit-dir", "myslice"},
-		{"implicit-parent", "myslice"}},
-	pkgs: map[string][]byte{
-		"implicit-parent": testutil.MustMakeDeb([]testutil.TarEntry{
-			testutil.Dir(0755, "./dir/"),
-			testutil.Reg(0644, "./dir/file", "random"),
-		}),
-		"explicit-dir": testutil.MustMakeDeb([]testutil.TarEntry{
-			testutil.Dir(01777, "./dir/"),
-		}),
-	},
-	release: map[string]string{
-		"slices/mydir/implicit-parent.yaml": `
-			package: implicit-parent
-			slices:
-				myslice:
-					contents:
-						/dir/file:
-		`,
-		"slices/mydir/explicit-dir.yaml": `
-			package: explicit-dir
-			slices:
-				myslice:
-					contents:
-						/dir/:
-		`,
-	},
-	filesystem: map[string]string{
-		"/dir/":     "dir 01777",
-		"/dir/file": "file 0644 a441b15f",
-	},
-	report: map[string]string{
-		"/dir/":     "dir 01777 {explicit-dir_myslice}",
-		"/dir/file": "file 0644 a441b15f {implicit-parent_myslice}",
-	},
-}, {
 	summary: "Valid same file in two slices in different packages",
 	slices: []setup.SliceKey{
 		{"test-package", "myslice"},
@@ -831,6 +793,191 @@ var slicerTests = []slicerTest{{
 		"/dir/other-file": "file 0644 63d5dd49 {test-package_myslice2}",
 		"/other-dir/file": "symlink ../dir/file {test-package_myslice1}",
 	},
+}, {
+	summary: "Same glob in several entries, with until:mutate",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice1"},
+		{"test-package", "myslice2"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**:
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/**: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/nested/other-file":        "file 0644 6b86b273",
+		"/dir/several/":                 "dir 0755",
+		"/dir/several/levels/":          "dir 0755",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
+		"/dir/":                         "dir 0755",
+		"/dir/file":                     "file 0644 cc55e2ec",
+		"/dir/nested/":                  "dir 0755",
+		"/dir/nested/file":              "file 0644 84237a05",
+		"/dir/other-file":               "file 0644 63d5dd49",
+		"/dir/several/levels/deep/":     "dir 0755",
+	},
+	report: map[string]string{
+		"/dir/":                         "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1,test-package_myslice2}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1,test-package_myslice2}",
+	},
+}, {
+	summary: "Same glob in several entries with until:mutate and reading from script",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice1"},
+		{"test-package", "myslice2"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/**:
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/nested/other-file":        "file 0644 6b86b273",
+		"/dir/several/":                 "dir 0755",
+		"/dir/several/levels/":          "dir 0755",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
+		"/dir/":                         "dir 0755",
+		"/dir/file":                     "file 0644 cc55e2ec",
+		"/dir/nested/":                  "dir 0755",
+		"/dir/nested/file":              "file 0644 84237a05",
+		"/dir/other-file":               "file 0644 63d5dd49",
+		"/dir/several/levels/deep/":     "dir 0755",
+	},
+	report: map[string]string{
+		"/dir/":                         "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1,test-package_myslice2}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1,test-package_myslice2}",
+	},
+}, {
+	summary: "Overlapping globs, until:mutate and reading from script",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice2"},
+		{"test-package", "myslice1"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**:
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/nested/**: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/":                         "dir 0755",
+		"/dir/file":                     "file 0644 cc55e2ec",
+		"/dir/nested/":                  "dir 0755",
+		"/dir/nested/file":              "file 0644 84237a05",
+		"/dir/nested/other-file":        "file 0644 6b86b273",
+		"/dir/other-file":               "file 0644 63d5dd49",
+		"/dir/several/":                 "dir 0755",
+		"/dir/several/levels/":          "dir 0755",
+		"/dir/several/levels/deep/":     "dir 0755",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
+	},
+	report: map[string]string{
+		// TODO, myslice2 should not appear in the report, this is pending PR #131.
+		"/dir/":                         "dir 0755 {test-package_myslice1}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1,test-package_myslice2}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1}",
+	},
+}, {
+	summary: "Overlapping glob and single entry, until:mutate and reading from script",
+	slices: []setup.SliceKey{
+		{"test-package", "myslice1"},
+		{"test-package", "myslice2"},
+	},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice1:
+					contents:
+						/dir/**:
+					mutate: |
+						content.read("/dir/file")
+				myslice2:
+					contents:
+						/dir/file: {until: mutate}
+					mutate: |
+						content.read("/dir/file")
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/":                         "dir 0755",
+		"/dir/file":                     "file 0644 cc55e2ec",
+		"/dir/nested/":                  "dir 0755",
+		"/dir/nested/file":              "file 0644 84237a05",
+		"/dir/nested/other-file":        "file 0644 6b86b273",
+		"/dir/other-file":               "file 0644 63d5dd49",
+		"/dir/several/":                 "dir 0755",
+		"/dir/several/levels/":          "dir 0755",
+		"/dir/several/levels/deep/":     "dir 0755",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
+	},
+	report: map[string]string{
+		"/dir/":                         "dir 0755 {test-package_myslice1}",
+		"/dir/file":                     "file 0644 cc55e2ec {test-package_myslice1,test-package_myslice2}",
+		"/dir/nested/":                  "dir 0755 {test-package_myslice1}",
+		"/dir/nested/file":              "file 0644 84237a05 {test-package_myslice1}",
+		"/dir/nested/other-file":        "file 0644 6b86b273 {test-package_myslice1}",
+		"/dir/other-file":               "file 0644 63d5dd49 {test-package_myslice1}",
+		"/dir/several/":                 "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/":          "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/":     "dir 0755 {test-package_myslice1}",
+		"/dir/several/levels/deep/file": "file 0644 6bc26dff {test-package_myslice1}",
+	},
 }}
 
 var defaultChiselYaml = `
@@ -890,71 +1037,73 @@ func (s *S) TestRun(c *C) {
 
 func runSlicerTests(c *C, tests []slicerTest) {
 	for _, test := range tests {
-		c.Logf("Summary: %s", test.summary)
+		for _, slices := range permutations(test.slices) {
+			c.Logf("Summary: %s", test.summary)
 
-		if _, ok := test.release["chisel.yaml"]; !ok {
-			test.release["chisel.yaml"] = string(defaultChiselYaml)
-		}
-
-		if test.pkgs == nil {
-			test.pkgs = map[string][]byte{
-				"test-package": testutil.PackageData["test-package"],
+			if _, ok := test.release["chisel.yaml"]; !ok {
+				test.release["chisel.yaml"] = string(defaultChiselYaml)
 			}
-		}
 
-		releaseDir := c.MkDir()
-		for path, data := range test.release {
-			fpath := filepath.Join(releaseDir, path)
-			err := os.MkdirAll(filepath.Dir(fpath), 0755)
-			c.Assert(err, IsNil)
-			err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
-			c.Assert(err, IsNil)
-		}
-
-		release, err := setup.ReadRelease(releaseDir)
-		c.Assert(err, IsNil)
-
-		selection, err := setup.Select(release, test.slices)
-		c.Assert(err, IsNil)
-
-		archives := map[string]archive.Archive{}
-		for name, setupArchive := range release.Archives {
-			archive := &testArchive{
-				options: archive.Options{
-					Label:      setupArchive.Name,
-					Version:    setupArchive.Version,
-					Suites:     setupArchive.Suites,
-					Components: setupArchive.Components,
-					Arch:       test.arch,
-				},
-				pkgs: test.pkgs,
+			if test.pkgs == nil {
+				test.pkgs = map[string][]byte{
+					"test-package": testutil.PackageData["test-package"],
+				}
 			}
-			archives[name] = archive
-		}
 
-		targetDir := c.MkDir()
-		options := slicer.RunOptions{
-			Selection: selection,
-			Archives:  archives,
-			TargetDir: targetDir,
-		}
-		if test.hackopt != nil {
-			test.hackopt(c, &options)
-		}
-		report, err := slicer.Run(&options)
-		if test.error == "" {
+			releaseDir := c.MkDir()
+			for path, data := range test.release {
+				fpath := filepath.Join(releaseDir, path)
+				err := os.MkdirAll(filepath.Dir(fpath), 0755)
+				c.Assert(err, IsNil)
+				err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
+				c.Assert(err, IsNil)
+			}
+
+			release, err := setup.ReadRelease(releaseDir)
 			c.Assert(err, IsNil)
-		} else {
-			c.Assert(err, ErrorMatches, test.error)
-			continue
-		}
 
-		if test.filesystem != nil {
-			c.Assert(testutil.TreeDump(targetDir), DeepEquals, test.filesystem)
-		}
+			selection, err := setup.Select(release, slices)
+			c.Assert(err, IsNil)
 
-		if test.report != nil {
-			c.Assert(treeDumpReport(report), DeepEquals, test.report)
+			archives := map[string]archive.Archive{}
+			for name, setupArchive := range release.Archives {
+				archive := &testArchive{
+					options: archive.Options{
+						Label:      setupArchive.Name,
+						Version:    setupArchive.Version,
+						Suites:     setupArchive.Suites,
+						Components: setupArchive.Components,
+						Arch:       test.arch,
+					},
+					pkgs: test.pkgs,
+				}
+				archives[name] = archive
+			}
+
+			targetDir := c.MkDir()
+			options := slicer.RunOptions{
+				Selection: selection,
+				Archives:  archives,
+				TargetDir: targetDir,
+			}
+			if test.hackopt != nil {
+				test.hackopt(c, &options)
+			}
+			report, err := slicer.Run(&options)
+			if test.error == "" {
+				c.Assert(err, IsNil)
+			} else {
+				c.Assert(err, ErrorMatches, test.error)
+				continue
+			}
+
+			if test.filesystem != nil {
+				c.Assert(testutil.TreeDump(targetDir), DeepEquals, test.filesystem)
+			}
+
+			if test.report != nil {
+				c.Assert(treeDumpReport(report), DeepEquals, test.report)
+			}
 		}
 	}
 }
@@ -993,4 +1142,38 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 		result[entry.Path] = fmt.Sprintf("%s {%s}", fsDump, strings.Join(slicesStr, ","))
 	}
 	return result
+}
+
+func permutations[S ~[]E, E any](s S) []S {
+	var output []S
+	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm
+	var generate func(k int, s S)
+	generate = func(k int, s S) {
+		// Copy the array before swapping elements.
+		r := make([]E, len(s))
+		copy(r, s)
+		s = r
+
+		if k == 1 {
+			output = append(output, s)
+			return
+		}
+		// Generate permutations with k-th unaltered
+		// Initially k = length(A)
+		generate(k-1, s)
+
+		// Generate permutations for k-th swapped with each k-1 initial
+		for i := 0; i < k-1; i += 1 {
+			// Swap choice dependent on parity of k (even or odd)
+			if k%2 == 0 {
+				s[i], s[k-1] = s[k-1], s[i]
+			} else {
+				s[0], s[k-1] = s[k-1], s[0]
+			}
+			generate(k-1, s)
+		}
+	}
+
+	generate(len(s), s)
+	return output
 }

--- a/internal/testutil/permutation.go
+++ b/internal/testutil/permutation.go
@@ -6,7 +6,7 @@ func Permutations[S ~[]E, E any](s S) []S {
 	var generate func(k int, s S)
 	generate = func(k int, s S) {
 		// Copy the array before swapping elements.
-		if k == 1 {
+		if k <= 1 {
 			r := make([]E, len(s))
 			copy(r, s)
 			output = append(output, r)

--- a/internal/testutil/permutation.go
+++ b/internal/testutil/permutation.go
@@ -1,0 +1,33 @@
+package testutil
+
+func Permutations[S ~[]E, E any](s S) []S {
+	var output []S
+	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm.
+	var generate func(k int, s S)
+	generate = func(k int, s S) {
+		// Copy the array before swapping elements.
+		if k == 1 {
+			r := make([]E, len(s))
+			copy(r, s)
+			output = append(output, r)
+			return
+		}
+		// Generate permutations with k-th unaltered.
+		// Initially k = length(A).
+		generate(k-1, s)
+
+		// Generate permutations for k-th swapped with each k-1 initial.
+		for i := 0; i < k-1; i += 1 {
+			// Swap choice dependent on parity of k (even or odd).
+			if k%2 == 0 {
+				s[i], s[k-1] = s[k-1], s[i]
+			} else {
+				s[0], s[k-1] = s[k-1], s[0]
+			}
+			generate(k-1, s)
+		}
+	}
+
+	generate(len(s), s)
+	return output
+}

--- a/internal/testutil/permutation.go
+++ b/internal/testutil/permutation.go
@@ -28,6 +28,8 @@ func Permutations[S ~[]E, E any](s S) []S {
 		}
 	}
 
-	generate(len(s), s)
+	sCpy := make([]E, len(s))
+	copy(sCpy, s)
+	generate(len(sCpy), sCpy)
 	return output
 }

--- a/internal/testutil/permutation.go
+++ b/internal/testutil/permutation.go
@@ -5,7 +5,6 @@ func Permutations[S ~[]E, E any](s S) []S {
 	// Heap's algorithm: https://en.wikipedia.org/wiki/Heap%27s_algorithm.
 	var generate func(k int, s S)
 	generate = func(k int, s S) {
-		// Copy the array before swapping elements.
 		if k <= 1 {
 			r := make([]E, len(s))
 			copy(r, s)

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -54,24 +54,22 @@ func (*permutationSuite) TestFuzzPermutations(c *C) {
 		for i := 2; i <= len(s); i++ {
 			expectedLen *= i
 		}
-		if len(permutations) != expectedLen {
-			c.Assert(len(permutations), Equals, expectedLen)
-		}
+		c.Assert(len(permutations), Equals, expectedLen)
 
-		duplicatedPerm := map[string]bool{}
+		duplicated := map[string]bool{}
 		for _, perm := range permutations {
 			// []byte is not comparable.
 			permStr := string(perm)
-			if _, ok := duplicatedPerm[permStr]; ok {
+			if _, ok := duplicated[permStr]; ok {
 				c.Fatalf("duplicated permutation: %v", perm)
 			}
-			duplicatedPerm[permStr] = true
+			duplicated[permStr] = true
 			// Check that the elements are the same.
 			sort.Slice(perm, func(i, j int) bool {
 				return perm[i] < perm[j]
 			})
 			if !bytes.Equal(perm, s) {
-				c.Fatalf("invalid elements in permutation: %v, of base slice: %v", perm, s)
+				c.Fatalf("invalid elements in permutation %v of base slice %v", perm, s)
 			}
 		}
 	}

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -1,7 +1,6 @@
 package testutil_test
 
 import (
-	"bytes"
 	"sort"
 
 	. "gopkg.in/check.v1"
@@ -68,9 +67,7 @@ func (*permutationSuite) TestFuzzPermutations(c *C) {
 			sort.Slice(perm, func(i, j int) bool {
 				return perm[i] < perm[j]
 			})
-			if !bytes.Equal(perm, s) {
-				c.Fatalf("invalid elements in permutation %v of base slice %v", perm, s)
-			}
+			c.Assert(perm, DeepEquals, s, Commentf("invalid elements in permutation %v of base slice %v", perm, s))
 		}
 	}
 }

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -58,9 +58,6 @@ func (*permutationSuite) TestFuzzPermutations(c *C) {
 			c.Assert(len(permutations), Equals, expectedLen)
 		}
 
-		sort.Slice(s, func(i, j int) bool {
-			return s[i] < s[j]
-		})
 		duplicatedPerm := map[string]bool{}
 		for _, perm := range permutations {
 			// []byte is not comparable.

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -1,0 +1,35 @@
+package testutil_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/testutil"
+)
+
+type permutationSuite struct{}
+
+var _ = check.Suite(&permutationSuite{})
+
+var permutationTests = []struct {
+	slice []any
+	res   [][]any
+}{
+	{
+		slice: []any{1},
+		res:   [][]any{{1}},
+	},
+	{
+		slice: []any{1, 2},
+		res:   [][]any{{1, 2}, {2, 1}},
+	},
+	{
+		slice: []any{1, 2, 3},
+		res:   [][]any{{1, 2, 3}, {2, 1, 3}, {3, 1, 2}, {1, 3, 2}, {2, 3, 1}, {3, 2, 1}},
+	},
+}
+
+func (*permutationSuite) TestPermutations(c *check.C) {
+	for _, test := range permutationTests {
+		c.Assert(testutil.Permutations(test.slice), check.DeepEquals, test.res)
+	}
+}


### PR DESCRIPTION
Due to several bugs and several limitations in the code, not all cases of selecting several slices of the same package worked. Specifically, we were not reporting the second slice correctly, which meant that the scripts could not select those paths. Additionally, there were several more problems when the slices had overlapping globs (which are valid in the same package). Mainly, the whole `until` calculation had to be redone, and the extractor had to be refactored to group by destination path, where before it was assuming there was only one.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
