### PR TITLE
refactor: split slicer into steps and remove unnecessary state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/chisel
 
-go 1.20
+go 1.21
 
 require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -482,7 +482,7 @@ func (s *S) TestExtractCreateCallback(c *C) {
 				relPath = relPath + "/"
 			}
 			sort.Slice(extractInfos, func(i, j int) bool {
-				return strings.Compare(extractInfos[i].Path, extractInfos[j].Path) < 0
+				return extractInfos[i].Path < extractInfos[j].Path
 			})
 			createExtractInfos[relPath] = extractInfos
 			return nil

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"golang.org/x/crypto/openpgp/packet"
@@ -545,11 +546,8 @@ func parsePackage(baseDir, pkgName, pkgPath string, data []byte) (*Package, erro
 				// Do not add the slice to its own essentials list.
 				continue
 			}
-			// TODO replace with slices.Contains once it is stable.
-			for _, sk := range slice.Essential {
-				if sk == sliceKey {
-					return nil, fmt.Errorf("package %s defined with redundant essential slice: %s", pkgName, refName)
-				}
+			if slices.Contains(slice.Essential, sliceKey) {
+				return nil, fmt.Errorf("package %s defined with redundant essential slice: %s", pkgName, refName)
 			}
 			slice.Essential = append(slice.Essential, sliceKey)
 		}
@@ -561,11 +559,8 @@ func parsePackage(baseDir, pkgName, pkgPath string, data []byte) (*Package, erro
 			if sliceKey.Package == slice.Package && sliceKey.Slice == slice.Name {
 				return nil, fmt.Errorf("cannot add slice to itself as essential %q in %s", refName, pkgPath)
 			}
-			// TODO replace with slices.Contains once it is stable.
-			for _, sk := range slice.Essential {
-				if sk == sliceKey {
-					return nil, fmt.Errorf("slice %s defined with redundant essential slice: %s", slice, refName)
-				}
+			if slices.Contains(slice.Essential, sliceKey) {
+				return nil, fmt.Errorf("slice %s defined with redundant essential slice: %s", slice, refName)
 			}
 			slice.Essential = append(slice.Essential, sliceKey)
 		}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -284,7 +284,7 @@ func Run(options *RunOptions) (*Report, error) {
 		}
 	}
 
-	err := removeUntilMutate(targetDirAbs, knownPaths)
+	err := removeAfterMutate(targetDirAbs, knownPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -292,9 +292,9 @@ func Run(options *RunOptions) (*Report, error) {
 	return report, nil
 }
 
-// removeUntilMutate removes entries marked with until: mutate. A path is marked
+// removeAfterMutate removes entries marked with until: mutate. A path is marked
 // only when all slices that refer to the path mark it with until: mutate.
-func removeUntilMutate(rootDir string, knownPaths map[string]pathData) error {
+func removeAfterMutate(rootDir string, knownPaths map[string]pathData) error {
 	var untilDirs []string
 	for path, data := range knownPaths {
 		if data.until != setup.UntilMutate {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -236,8 +236,7 @@ func Run(options *RunOptions) (*Report, error) {
 	// Create new content not coming from packages.
 	done := make(map[string]bool)
 	for _, slice := range options.Selection.Slices {
-		archiveName := options.Selection.Release.Packages[slice.Package].Archive
-		arch := options.Archives[archiveName].Options().Arch
+		arch := archives[slice.Package].Options().Arch
 		for relPath, pathInfo := range slice.Contents {
 			if len(pathInfo.Arch) > 0 && !slices.Contains(pathInfo.Arch, arch) {
 				continue

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s

--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ backends:
     discard:
       docker rm -f $SPREAD_SYSTEM
     systems:
-      - ubuntu-23.04:
+      - ubuntu-24.04:
           username: ubuntu
           password: ubuntu
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Streamline `slicer.go` moving all of the non essential functionality to self-contained function / abstractions and adding comments where necessary. Most importantly, combine all maps that recorded information about paths into one (`knownPaths`, `pathInfos` and `pathUntil`) and record the information in the same place instead of during several stages.