### PR TITLE
hotfix: use strings.TrimPrefix() for relative paths

### DIFF
--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -180,7 +180,7 @@ func Run(options *RunOptions) (*Report, error) {
 			return nil
 		}
 
-		relPath := filepath.Clean("/" + strings.TrimLeft(o.Path, targetDir))
+		relPath := filepath.Clean("/" + strings.TrimPrefix(o.Path, targetDir))
 		if o.Mode.IsDir() {
 			relPath = relPath + "/"
 		}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1025,8 +1025,7 @@ var slicerTests = []slicerTest{{
 	summary: "Relative paths are properly determined during extraction",
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},
 	pkgs: map[string][]byte{
-		"test-package": testutil.MustMakeDeb(append(
-			testutil.TestPackageEntries,
+		"test-package": testutil.MustMakeDeb([]testutil.TarEntry{
 			// This particular path starting with "/foo" is chosen to test for
 			// a particular bug; which appeared due to the usage of
 			// strings.TrimLeft() instead strings.TrimPrefix() to determine a
@@ -1034,11 +1033,12 @@ var slicerTests = []slicerTest{{
 			// prefix, the desired relative path was not produced.
 			// See https://github.com/canonical/chisel/pull/145.
 			testutil.Dir(0755, "./foo-bar/"),
-		)),
+		}),
 	},
 	hackopt: func(c *C, opts *slicer.RunOptions) {
 		opts.TargetDir = filepath.Join(filepath.Clean(opts.TargetDir), "foo")
-		os.Mkdir(opts.TargetDir, 0755)
+		err := os.Mkdir(opts.TargetDir, 0755)
+		c.Assert(err, IsNil)
 	},
 	release: map[string]string{
 		"slices/mydir/test-package.yaml": `

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -616,6 +616,19 @@ var slicerTests = []slicerTest{{
 }, {
 	summary: "Can list parent directories of normal paths",
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},
+	pkgs: map[string][]byte{
+		"test-package": testutil.MustMakeDeb(append(
+			testutil.TestPackageEntries,
+			// This particular path starting with "/check" is chosen to test for
+			// a particular bug; which appeared due to the usage of
+			// strings.TrimLeft() instead strings.TrimPrefix() to determine a
+			// relative path. Since TrimLeft takes in a cutset instead of a
+			// prefix, the desired relative path was not produced. The check.v1
+			// module creates temporary path with the word "check" within. Thus,
+			// this particular path reproduced the bug.
+			testutil.Dir(0755, "./check-foo/"),
+		)),
+	},
 	release: map[string]string{
 		"slices/mydir/test-package.yaml": `
 			package: test-package
@@ -624,12 +637,14 @@ var slicerTests = []slicerTest{{
 					contents:
 						/a/b/c: {text: foo}
 						/x/y/: {make: true}
+						/check-foo/:
 					mutate: |
 						content.list("/")
 						content.list("/a")
 						content.list("/a/b")
 						content.list("/x")
 						content.list("/x/y")
+						content.list("/check-foo/")
 		`,
 	},
 }, {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1022,7 +1022,7 @@ var slicerTests = []slicerTest{{
 	filesystem: map[string]string{},
 	report:     map[string]string{},
 }, {
-	summary: "Relative paths are properly determined during extraction",
+	summary: "Relative paths are properly trimmed during extraction",
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},
 	pkgs: map[string][]byte{
 		"test-package": testutil.MustMakeDeb([]testutil.TarEntry{


### PR DESCRIPTION
Use ``strings.TrimPrefix()`` for relative paths instead of ``strings.TrimLeft()``, since ``TrimLeft`` takes in a cutset instead of a prefix sub-string.

In this particular case, if the ``--root`` (output) directory is ``/tmp/foo`` and we are determining the relative path for ``/tmp/foo/tmp-foo``, the relative path would result in ``/-foo`` since ``/tmp/foo/tmp`` would be matched by the ``/tmp/foo/`` cutset.

This results in a flawed map of ``knownPaths`` inside slicer.go, which is only checked by the mutation script functions such as ``content.list()``.

This commit fixes said bug.