### PR TITLE
fix: deprecate "chisel-v1" format

### DIFF
--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -148,13 +148,13 @@ var infoTests = []infoTest{{
 var testKey = testutil.PGPKeys["key1"]
 
 var defaultChiselYaml = `
-	format: chisel-v1
+	format: v1
 	archives:
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
-			v1-public-keys: [test-key]
-	v1-public-keys:
+			public-keys: [test-key]
+	public-keys:
 		test-key:
 			id: ` + testKey.ID + `
 			armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t")

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -328,8 +328,6 @@ type yamlRelease struct {
 	Format   string                 `yaml:"format"`
 	Archives map[string]yamlArchive `yaml:"archives"`
 	PubKeys  map[string]yamlPubKey  `yaml:"public-keys"`
-	// V1PubKeys is used for compatibility with format "chisel-v1".
-	V1PubKeys map[string]yamlPubKey `yaml:"v1-public-keys"`
 }
 
 type yamlArchive struct {
@@ -338,8 +336,6 @@ type yamlArchive struct {
 	Components []string `yaml:"components"`
 	Default    bool     `yaml:"default"`
 	PubKeys    []string `yaml:"public-keys"`
-	// V1PubKeys is used for compatibility with format "chisel-v1".
-	V1PubKeys []string `yaml:"v1-public-keys"`
 }
 
 type yamlPackage struct {
@@ -426,17 +422,8 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s: cannot parse release definition: %v", fileName, err)
 	}
-	if yamlVar.Format != "chisel-v1" && yamlVar.Format != "v1" {
+	if yamlVar.Format != "v1" {
 		return nil, fmt.Errorf("%s: unknown format %q", fileName, yamlVar.Format)
-	}
-	// If format is "chisel-v1" we have to translate from the yaml key "v1-public-keys" to
-	// "public-keys".
-	if yamlVar.Format == "chisel-v1" {
-		yamlVar.PubKeys = yamlVar.V1PubKeys
-		for name, details := range yamlVar.Archives {
-			details.PubKeys = details.V1PubKeys
-			yamlVar.Archives[name] = details
-		}
 	}
 	if len(yamlVar.Archives) == 0 {
 		return nil, fmt.Errorf("%s: no archives defined", fileName)
@@ -478,11 +465,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			release.DefaultArchive = archiveName
 		}
 		if len(details.PubKeys) == 0 {
-			if yamlVar.Format == "chisel-v1" {
-				return nil, fmt.Errorf("%s: archive %q missing v1-public-keys field", fileName, archiveName)
-			} else {
-				return nil, fmt.Errorf("%s: archive %q missing public-keys field", fileName, archiveName)
-			}
+			return nil, fmt.Errorf("%s: archive %q missing public-keys field", fileName, archiveName)
 		}
 		var archiveKeys []*packet.PublicKey
 		for _, keyName := range details.PubKeys {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/crypto/openpgp/packet"
 	. "gopkg.in/check.v1"
@@ -1583,13 +1584,13 @@ var setupTests = []setupTest{{
 }}
 
 var defaultChiselYaml = `
-	format: chisel-v1
+	format: v1
 	archives:
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
-			v1-public-keys: [test-key]
-	v1-public-keys:
+			public-keys: [test-key]
+	public-keys:
 		test-key:
 			id: ` + testKey.ID + `
 			armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -759,18 +759,18 @@ var slicerTests = []slicerTest{{
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},
 	release: map[string]string{
 		"chisel.yaml": `
-			format: chisel-v1
+			format: v1
 			archives:
 				foo:
 					version: 22.04
 					components: [main, universe]
 					default: true
-					v1-public-keys: [test-key]
+					public-keys: [test-key]
 				bar:
 					version: 22.04
 					components: [main]
-					v1-public-keys: [test-key]
-			v1-public-keys:
+					public-keys: [test-key]
+			public-keys:
 				test-key:
 					id: ` + testKey.ID + `
 					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
@@ -1054,13 +1054,13 @@ var slicerTests = []slicerTest{{
 }}
 
 var defaultChiselYaml = `
-	format: chisel-v1
+	format: v1
 	archives:
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
-			v1-public-keys: [test-key]
-	v1-public-keys:
+			public-keys: [test-key]
+	public-keys:
 		test-key:
 			id: ` + testKey.ID + `
 			armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
@@ -1088,28 +1088,7 @@ func (a *testArchive) Exists(pkg string) bool {
 }
 
 func (s *S) TestRun(c *C) {
-	// Run tests for format chisel-v1.
-	runSlicerTests(c, slicerTests)
-
-	// Run tests for format v1.
-	v1SlicerTests := make([]slicerTest, len(slicerTests))
-	for i, t := range slicerTests {
-		t.error = strings.Replace(t.error, "chisel-v1", "v1", -1)
-		t.error = strings.Replace(t.error, "v1-public-keys", "public-keys", -1)
-		m := map[string]string{}
-		for k, v := range t.release {
-			v = strings.Replace(v, "chisel-v1", "v1", -1)
-			v = strings.Replace(v, "v1-public-keys", "public-keys", -1)
-			m[k] = v
-		}
-		t.release = m
-		v1SlicerTests[i] = t
-	}
-	runSlicerTests(c, v1SlicerTests)
-}
-
-func runSlicerTests(c *C, tests []slicerTest) {
-	for _, test := range tests {
+	for _, test := range slicerTests {
 		for _, slices := range testutil.Permutations(test.slices) {
 			c.Logf("Summary: %s", test.summary)
 


### PR DESCRIPTION
This commit depreciates support for the "chisel-v1" format in chisel. Notably the following fields/values are no longer supported:

    - The "chisel-v1" value for top-level field "format". Use "v1"
      instead.
    - The "<archive>.v1-public-keys" field. Use "<archive>.public-keys"
      instead.
    - The top-level "v1-public-keys" field. Use "public-keys" instead.

BREAKING CHANGE: New versions of chisel which includes this commit will
    no longer support the "chisel-v1" format in chisel-releases. Either
    update the "chisel.yaml" file in chisel-releases or use a lower
    version which does not have this commit.

-----
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?