### PR TITLE
feat: handle hardlinks

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -246,11 +246,17 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				}
 			}
 			// Create the entry itself.
+			link := tarHeader.Linkname
+			if tarHeader.Typeflag == tar.TypeLink {
+				// A hard link requires the real path of the target file.
+				link = filepath.Join(options.TargetDir, link)
+			}
+
 			createOptions := &fsutil.CreateOptions{
 				Path:        filepath.Join(options.TargetDir, targetPath),
 				Mode:        tarHeader.FileInfo().Mode(),
 				Data:        pathReader,
-				Link:        tarHeader.Linkname,
+				Link:        link,
 				MakeParents: true,
 			}
 			err := options.Create(extractInfos, createOptions)

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -15,13 +15,15 @@ import (
 )
 
 type createTest struct {
+	summary string
 	options fsutil.CreateOptions
-	hackdir func(c *C, dir string)
+	hackopt func(c *C, targetDir string, options *fsutil.CreateOptions)
 	result  map[string]string
 	error   string
 }
 
 var createTests = []createTest{{
+	summary: "Create a file and its parent directory",
 	options: fsutil.CreateOptions{
 		Path:        "foo/bar",
 		Data:        bytes.NewBufferString("data1"),
@@ -33,6 +35,7 @@ var createTests = []createTest{{
 		"/foo/bar": "file 0444 5b41362b",
 	},
 }, {
+	summary: "Create a symlink",
 	options: fsutil.CreateOptions{
 		Path:        "foo/bar",
 		Link:        "../baz",
@@ -44,6 +47,7 @@ var createTests = []createTest{{
 		"/foo/bar": "symlink ../baz",
 	},
 }, {
+	summary: "Create a directory",
 	options: fsutil.CreateOptions{
 		Path:        "foo/bar",
 		Mode:        fs.ModeDir | 0444,
@@ -54,6 +58,7 @@ var createTests = []createTest{{
 		"/foo/bar/": "dir 0444",
 	},
 }, {
+	summary: "Create a directory with sticky bit",
 	options: fsutil.CreateOptions{
 		Path: "tmp",
 		Mode: fs.ModeDir | fs.ModeSticky | 0775,
@@ -62,37 +67,101 @@ var createTests = []createTest{{
 		"/tmp/": "dir 01775",
 	},
 }, {
+	summary: "Cannot create a parent directory without MakeParents set",
 	options: fsutil.CreateOptions{
 		Path: "foo/bar",
 		Mode: fs.ModeDir | 0775,
 	},
-	error: `.*: no such file or directory`,
+	error: `mkdir \/[^ ]*\/foo/bar: no such file or directory`,
 }, {
+	summary: "Re-creating an existing directory keeps the original mode",
 	options: fsutil.CreateOptions{
 		Path: "foo",
 		Mode: fs.ModeDir | 0775,
 	},
-	hackdir: func(c *C, dir string) {
-		c.Assert(os.Mkdir(filepath.Join(dir, "foo/"), fs.ModeDir|0765), IsNil)
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		c.Assert(os.Mkdir(filepath.Join(targetDir, "foo/"), fs.ModeDir|0765), IsNil)
 	},
 	result: map[string]string{
 		// mode is not updated.
 		"/foo/": "dir 0765",
 	},
 }, {
+	summary: "Re-creating an existing file keeps the original mode",
 	options: fsutil.CreateOptions{
 		Path: "foo",
 		// Mode should be ignored for existing entry.
 		Mode: 0644,
 		Data: bytes.NewBufferString("changed"),
 	},
-	hackdir: func(c *C, dir string) {
-		c.Assert(os.WriteFile(filepath.Join(dir, "foo"), []byte("data"), 0666), IsNil)
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "foo"), []byte("data"), 0666), IsNil)
 	},
 	result: map[string]string{
 		// mode is not updated.
 		"/foo": "file 0666 d67e2e94",
 	},
+}, {
+	summary: "Create a hard link",
+	options: fsutil.CreateOptions{
+		Path:        "dir/hardlink",
+		Link:        "file",
+		Mode:        0644,
+		MakeParents: true,
+	},
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "file"), []byte("data"), 0644), IsNil)
+		// An absolute path is required to create a hard link.
+		options.Link = filepath.Join(targetDir, options.Link)
+	},
+	result: map[string]string{
+		"/file":         "file 0644 3a6eb079",
+		"/dir/":         "dir 0755",
+		"/dir/hardlink": "file 0644 3a6eb079",
+	},
+}, {
+	summary: "Cannot create a hard link if the link target does not exist",
+	options: fsutil.CreateOptions{
+		Path:        "dir/hardlink",
+		Link:        "missing-file",
+		Mode:        0644,
+		MakeParents: true,
+	},
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		options.Link = filepath.Join(targetDir, options.Link)
+	},
+	error: `link target does not exist: \/[^ ]*\/missing-file`,
+}, {
+	summary: "Re-creating a duplicated hard link keeps the original link",
+	options: fsutil.CreateOptions{
+		Path:        "hardlink",
+		Link:        "file",
+		Mode:        0644,
+		MakeParents: true,
+	},
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "file"), []byte("data"), 0644), IsNil)
+		c.Assert(os.Link(filepath.Join(targetDir, "file"), filepath.Join(targetDir, "hardlink")), IsNil)
+		options.Link = filepath.Join(targetDir, options.Link)
+	},
+	result: map[string]string{
+		"/file":     "file 0644 3a6eb079",
+		"/hardlink": "file 0644 3a6eb079",
+	},
+}, {
+	summary: "Cannot create a hard link if the link path exists and it is not a hard link to the target",
+	options: fsutil.CreateOptions{
+		Path:        "hardlink",
+		Link:        "file",
+		Mode:        0644,
+		MakeParents: true,
+	},
+	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "file"), []byte("data"), 0644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "hardlink"), []byte("data"), 0644), IsNil)
+		options.Link = filepath.Join(targetDir, options.Link)
+	},
+	error: `path \/[^ ]*\/hardlink already exists`,
 }}
 
 func (s *S) TestCreate(c *C) {
@@ -102,17 +171,18 @@ func (s *S) TestCreate(c *C) {
 	}()
 
 	for _, test := range createTests {
+		c.Logf("Test: %s", test.summary)
 		if test.result == nil {
 			// Empty map for no files created.
 			test.result = make(map[string]string)
 		}
 		c.Logf("Options: %v", test.options)
 		dir := c.MkDir()
-		if test.hackdir != nil {
-			test.hackdir(c, dir)
-		}
 		options := test.options
 		options.Path = filepath.Join(dir, options.Path)
+		if test.hackopt != nil {
+			test.hackopt(c, dir, &options)
+		}
 		entry, err := fsutil.Create(&options)
 
 		if test.error != "" {
@@ -122,14 +192,24 @@ func (s *S) TestCreate(c *C) {
 
 		c.Assert(err, IsNil)
 		c.Assert(testutil.TreeDump(dir), DeepEquals, test.result)
+
 		// [fsutil.Create] does not return information about parent directories
 		// created implicitly. We only check for the requested path.
-		entry.Path = strings.TrimPrefix(entry.Path, dir)
-		// Add the slashes that TreeDump adds to the path.
-		slashPath := "/" + test.options.Path
-		if test.options.Mode.IsDir() {
-			slashPath = slashPath + "/"
+		if entry.Link != "" && entry.Mode&fs.ModeSymlink == 0 {
+			// Entry is a hard link.
+			pathInfo, err := os.Lstat(entry.Path)
+			c.Assert(err, IsNil)
+			linkInfo, err := os.Lstat(entry.Link)
+			c.Assert(err, IsNil)
+			os.SameFile(pathInfo, linkInfo)
+		} else {
+			entry.Path = strings.TrimPrefix(entry.Path, dir)
+			// Add the slashes that TreeDump adds to the path.
+			slashPath := "/" + test.options.Path
+			if test.options.Mode.IsDir() {
+				slashPath = slashPath + "/"
+			}
+			c.Assert(testutil.TreeDumpEntry(entry), DeepEquals, test.result[slashPath])
 		}
-		c.Assert(testutil.TreeDumpEntry(entry), DeepEquals, test.result[slashPath])
 	}
 }

--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -197,3 +197,16 @@ func Lnk(mode int64, path, target string) TarEntry {
 		},
 	}
 }
+
+// Hln is a shortcut for creating a hard link TarEntry structure (with
+// tar.Typeflag set to tar.TypeLink). Hln stands for "Hard LiNk".
+func Hln(mode int64, path, target string) TarEntry {
+	return TarEntry{
+		Header: tar.Header{
+			Typeflag: tar.TypeLink,
+			Name:     path,
+			Mode:     mode,
+			Linkname: target,
+		},
+	}
+}

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,7 +74,12 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0: // Regular
+	case 0:
+		// Hard link.
+		if entry.Link != "" {
+			return fmt.Sprintf("hardlink %s", entry.Link)
+		}
+		// Regular file.
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {


### PR DESCRIPTION
This commit enables Chisel to be able to handle hardlinks and extract them from package tarballs.

At the moment, if a slice is extracting a hardlink it also needs to extract the file that it points to, either as part of that slice or in its essentials.

-----
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?