### PR TITLE
ci: report vulnerabilities and fail on HIGH,CRITICAL

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,8 @@ jobs:
   scan:
     name: Scan for known vulnerabilities
     runs-on: ubuntu-latest
+    env:
+      TRIVY_RESULTS: 'trivy-results.sarif'
     steps:
       - uses: actions/checkout@v3
 
@@ -18,3 +20,23 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
+          format: 'sarif'
+          output: ${{ env.TRIVY_RESULTS }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ env.TRIVY_RESULTS }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TRIVY_RESULTS }}
+          path: ${{ env.TRIVY_RESULTS }}
+
+      - name: Raise error on HIGH,CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,10 +1,8 @@
 name: Security
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "0 1 * * *"
 
 jobs:
   scan:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

# Problem

The current GH workflow runs the Trivy scan but doesn't react to its findings, exiting successfully even if there are vulnerabilities.

# In this PR

This PR adds an additional Trivy execution that raises an error on HIGH and CRITICAL vulnerabilities. It also uploads the vulnerability report to the CI run and the GitHub Security dashboard ([example](https://github.com/cjdcordeiro/chisel/security/code-scanning))