### PR TITLE
chore: publish release checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,17 +89,17 @@ jobs:
           CHISEL_VERSION: ${{ steps.build.outputs.CHISEL_VERSION }}
         run: |
           ARCHIVE_FILE=chisel_${CHISEL_VERSION}_${GOOS}_${GOARCH}.tar.gz
-          ARCHIVE_FILE_CKSUM="${ARCHIVE_FILE}.sha384"
+          ARCHIVE_FILE_SHA384="${ARCHIVE_FILE}.sha384"
           echo "Creating archive $ARCHIVE_FILE"
 
           mkdir -p dist/build
           cp chisel LICENSE README.md dist/build
           find dist/build -printf "%P\n" | tar -czf dist/$ARCHIVE_FILE --no-recursion -C dist/build -T -
-          cd dist/ && sha384sum "${ARCHIVE_FILE}" > "${ARCHIVE_FILE_CKSUM}" && cd -
+          cd dist/ && sha384sum "${ARCHIVE_FILE}" > "${ARCHIVE_FILE_SHA384}" && cd -
 
           # Share variables with subsequent steps
           echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT
-          echo "ARCHIVE_FILE_CKSUM=${ARCHIVE_FILE_CKSUM}" >>$GITHUB_OUTPUT
+          echo "ARCHIVE_FILE_SHA384=${ARCHIVE_FILE_SHA384}" >>$GITHUB_OUTPUT
 
       - name: Upload archive as Actions artifact
         uses: actions/upload-artifact@v3
@@ -107,16 +107,16 @@ jobs:
           name: ${{ steps.archive.outputs.ARCHIVE_FILE }}
           path: |
             dist/${{ steps.archive.outputs.ARCHIVE_FILE }}
-            dist/${{ steps.archive.outputs.ARCHIVE_FILE_CKSUM }}
+            dist/${{ steps.archive.outputs.ARCHIVE_FILE_SHA384 }}
 
       - name: Upload archive to release
         env:
           CHISEL_VERSION: ${{ steps.build.outputs.CHISEL_VERSION }}
           ARCHIVE_FILE: ${{ steps.archive.outputs.ARCHIVE_FILE }}
-          ARCHIVE_FILE_CKSUM: ${{ steps.archive.outputs.ARCHIVE_FILE_CKSUM }}
+          ARCHIVE_FILE_SHA384: ${{ steps.archive.outputs.ARCHIVE_FILE_SHA384 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'release' }}
         run: |
           echo "Uploading $ARCHIVE_FILE to release $CHISEL_VERSION"
           gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE
-          gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE_CKSUM
+          gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE_SHA384

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,27 +89,34 @@ jobs:
           CHISEL_VERSION: ${{ steps.build.outputs.CHISEL_VERSION }}
         run: |
           ARCHIVE_FILE=chisel_${CHISEL_VERSION}_${GOOS}_${GOARCH}.tar.gz
+          ARCHIVE_FILE_CKSUM="${ARCHIVE_FILE}.sha384"
           echo "Creating archive $ARCHIVE_FILE"
 
           mkdir -p dist/build
           cp chisel LICENSE README.md dist/build
           find dist/build -printf "%P\n" | tar -czf dist/$ARCHIVE_FILE --no-recursion -C dist/build -T -
+          sha384sum "dist/${ARCHIVE_FILE}" > "dist/${ARCHIVE_FILE_CKSUM}"
 
           # Share variables with subsequent steps
           echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT
+          echo "ARCHIVE_FILE_CKSUM=${ARCHIVE_FILE_CKSUM}" >>$GITHUB_OUTPUT
 
       - name: Upload archive as Actions artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.archive.outputs.ARCHIVE_FILE }}
-          path: dist/${{ steps.archive.outputs.ARCHIVE_FILE }}
+          path:
+            dist/${{ steps.archive.outputs.ARCHIVE_FILE }}
+            dist/${{ steps.archive.outputs.ARCHIVE_FILE_CKSUM }}
 
       - name: Upload archive to release
         env:
           CHISEL_VERSION: ${{ steps.build.outputs.CHISEL_VERSION }}
           ARCHIVE_FILE: ${{ steps.archive.outputs.ARCHIVE_FILE }}
+          ARCHIVE_FILE_CKSUM: ${{ steps.archive.outputs.ARCHIVE_FILE_CKSUM }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'release' }}
         run: |
           echo "Uploading $ARCHIVE_FILE to release $CHISEL_VERSION"
           gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE
+          gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE_CKSUM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.archive.outputs.ARCHIVE_FILE }}
-          path:
+          path: |
             dist/${{ steps.archive.outputs.ARCHIVE_FILE }}
             dist/${{ steps.archive.outputs.ARCHIVE_FILE_CKSUM }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,10 +92,10 @@ jobs:
           ARCHIVE_FILE_SHA384="${ARCHIVE_FILE}.sha384"
           echo "Creating archive $ARCHIVE_FILE"
 
-          mkdir -p dist/build
-          cp chisel LICENSE README.md dist/build
-          find dist/build -printf "%P\n" | tar -czf dist/$ARCHIVE_FILE --no-recursion -C dist/build -T -
-          cd dist/ && sha384sum "${ARCHIVE_FILE}" > "${ARCHIVE_FILE_SHA384}" && cd -
+          mkdir -p dist/
+          cp chisel LICENSE README.md dist/
+          find dist -printf "%P\n" | tar -czf $ARCHIVE_FILE --no-recursion -C dist -T -
+          sha384sum "${ARCHIVE_FILE}" > "${ARCHIVE_FILE_SHA384}"
 
           # Share variables with subsequent steps
           echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT
@@ -106,8 +106,8 @@ jobs:
         with:
           name: ${{ steps.archive.outputs.ARCHIVE_FILE }}
           path: |
-            dist/${{ steps.archive.outputs.ARCHIVE_FILE }}
-            dist/${{ steps.archive.outputs.ARCHIVE_FILE_SHA384 }}
+            ${{ steps.archive.outputs.ARCHIVE_FILE }}
+            ${{ steps.archive.outputs.ARCHIVE_FILE_SHA384 }}
 
       - name: Upload archive to release
         env:
@@ -118,5 +118,5 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           echo "Uploading $ARCHIVE_FILE to release $CHISEL_VERSION"
-          gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE
-          gh release upload $CHISEL_VERSION dist/$ARCHIVE_FILE_SHA384
+          gh release upload $CHISEL_VERSION $ARCHIVE_FILE
+          gh release upload $CHISEL_VERSION $ARCHIVE_FILE_SHA384

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           mkdir -p dist/build
           cp chisel LICENSE README.md dist/build
           find dist/build -printf "%P\n" | tar -czf dist/$ARCHIVE_FILE --no-recursion -C dist/build -T -
-          sha384sum "dist/${ARCHIVE_FILE}" > "dist/${ARCHIVE_FILE_CKSUM}"
+          cd dist/ && sha384sum "${ARCHIVE_FILE}" > "${ARCHIVE_FILE_CKSUM}" && cd -
 
           # Share variables with subsequent steps
           echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
On release events, publish checksum of the binary tarballs that we already publish.

Closes #122.