### PR TITLE
feat: support multiple archives with "priority" field

### DIFF
--- a/cmd/chisel/cmd_find_test.go
+++ b/cmd/chisel/cmd_find_test.go
@@ -33,8 +33,6 @@ func makeSamplePackage(pkg string, slices []string) *setup.Package {
 }
 
 var sampleRelease = &setup.Release{
-	DefaultArchive: "ubuntu",
-
 	Archives: map[string]*setup.Archive{
 		"ubuntu": {
 			Name:       "ubuntu",

--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -25,7 +25,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg1_myslice1"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:
@@ -37,7 +36,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg2"},
 	stdout: `
 		package: mypkg2
-		archive: ubuntu
 		slices:
 			myslice:
 				contents:
@@ -49,7 +47,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg1_myslice2", "mypkg1_myslice1"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:
@@ -65,7 +62,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg1_myslice1", "mypkg2", "mypkg1_myslice2"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:
@@ -76,7 +72,6 @@ var infoTests = []infoTest{{
 					- mypkg2_myslice
 		---
 		package: mypkg2
-		archive: ubuntu
 		slices:
 			myslice:
 				contents:
@@ -88,7 +83,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg1_myslice1", "mypkg1"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:
@@ -104,7 +98,6 @@ var infoTests = []infoTest{{
 	query:   []string{"mypkg1_myslice1", "mypkg1_myslice1", "mypkg1_myslice1"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:
@@ -121,7 +114,6 @@ var infoTests = []infoTest{{
 	query:   []string{"foo", "mypkg1_myslice1", "bar_foo"},
 	stdout: `
 		package: mypkg1
-		archive: ubuntu
 		slices:
 			myslice1:
 				contents:

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -553,6 +553,9 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			return nil, fmt.Errorf("%s: archive %q missing components field", fileName, archiveName)
 		}
 		if details.Default && defaultArchive != "" {
+			if archiveName < defaultArchive {
+				archiveName, defaultArchive = defaultArchive, archiveName
+			}
 			return nil, fmt.Errorf("%s: more than one default archive: %s, %s", fileName, defaultArchive, archiveName)
 		}
 		if details.Default {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -540,7 +540,6 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 
 	// For compatibility if there is a default archive set and priorities are
 	// not being used, we will revert back to the default archive behaviour.
-	hasDefault := false
 	hasPriority := false
 	var defaultArchive string
 	for archiveName, details := range yamlVar.Archives {
@@ -558,7 +557,6 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		}
 		if details.Default {
 			defaultArchive = archiveName
-			hasDefault = true
 		}
 		if len(details.PubKeys) == 0 {
 			return nil, fmt.Errorf("%s: archive %q missing public-keys field", fileName, archiveName)
@@ -586,7 +584,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			PubKeys:    archiveKeys,
 		}
 	}
-	if hasDefault && !hasPriority {
+	if defaultArchive != "" && !hasPriority {
 		// For compatibility with the default archive behaviour we will set
 		// negative priorities to all but the default one, which means all
 		// others will be ignored unless pinned.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -591,7 +591,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		// negative priorities to all but the default one, which means all
 		// others will be ignored unless pinned.
 		i := -1
-		for archiveName, _ := range yamlVar.Archives {
+		for archiveName := range yamlVar.Archives {
 			release.Archives[archiveName].Priority = i
 			i--
 		}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -588,10 +588,14 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		// For compatibility with the default archive behaviour we will set
 		// negative priorities to all but the default one, which means all
 		// others will be ignored unless pinned.
-		i := -1
+		var archiveNames []string
 		for archiveName := range yamlVar.Archives {
-			release.Archives[archiveName].Priority = i
-			i--
+			archiveNames = append(archiveNames, archiveName)
+		}
+		// Make it deterministic.
+		slices.Sort(archiveNames)
+		for i, archiveName := range archiveNames {
+			release.Archives[archiveName].Priority = -i - 1
 		}
 		release.Archives[defaultArchive].Priority = 0
 	}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1739,7 +1739,7 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy]
-					v1-public-keys: [test-key]
+					public-keys: [test-key]
 			public-keys:
 				test-key:
 					id: ` + testKey.ID + `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -73,8 +73,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -86,10 +84,9 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
-				Slices:  map[string]*setup.Slice{},
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
 			},
 		},
 	},
@@ -117,8 +114,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -130,9 +125,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -179,8 +173,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -192,9 +184,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -440,8 +431,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -453,9 +442,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice1": {
 						Package: "mypkg",
@@ -655,8 +643,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -668,9 +654,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -695,8 +680,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -708,9 +691,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -736,8 +718,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -749,9 +729,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -766,7 +745,7 @@ var setupTests = []setupTest{{
 		},
 	},
 }, {
-	summary: "Multiple archives",
+	summary: "Multiple archives with priorities",
 	input: map[string]string{
 		"chisel.yaml": `
 			format: chisel-v1
@@ -775,12 +754,13 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy]
-					default: true
+					priority: 20
 					v1-public-keys: [test-key]
 				bar:
 					version: 22.04
 					components: [universe]
 					suites: [jammy-updates]
+					priority: -10
 					v1-public-keys: [test-key]
 			v1-public-keys:
 				test-key:
@@ -792,14 +772,13 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "foo",
-
 		Archives: map[string]*setup.Archive{
 			"foo": {
 				Name:       "foo",
 				Version:    "22.04",
 				Suites:     []string{"jammy"},
 				Components: []string{"main", "universe"},
+				Priority:   20,
 				PubKeys:    []*packet.PublicKey{testKey.PubKey},
 			},
 			"bar": {
@@ -807,18 +786,65 @@ var setupTests = []setupTest{{
 				Version:    "22.04",
 				Suites:     []string{"jammy-updates"},
 				Components: []string{"universe"},
+				Priority:   -10,
 				PubKeys:    []*packet.PublicKey{testKey.PubKey},
 			},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "foo",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
-				Slices:  map[string]*setup.Slice{},
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
 			},
 		},
 	},
+}, {
+	summary: "Two archives cannot have same priority",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					priority: 20
+					v1-public-keys: [test-key]
+				bar:
+					version: 22.04
+					components: [universe]
+					suites: [jammy-updates]
+					priority: 20
+					v1-public-keys: [test-key]
+			v1-public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	relerror: `chisel.yaml: archives "bar" and "foo" have the same priority value of 20`,
+}, {
+	summary: "Invalid archive priority",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					priority: 10000
+					v1-public-keys: [test-key]
+			v1-public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+	},
+	relerror: `chisel.yaml: archive "foo" has invalid priority value of 10000`,
 }, {
 	summary: "Extra fields in YAML are ignored (necessary for forward compatibility)",
 	input: map[string]string{
@@ -849,8 +875,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -862,9 +886,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -888,12 +911,13 @@ var setupTests = []setupTest{{
 					components: [main, universe]
 					suites: [jammy]
 					v1-public-keys: [extra-key]
-					default: true
+					priority: 20
 				bar:
 					version: 22.04
 					components: [universe]
 					suites: [jammy-updates]
 					v1-public-keys: [test-key, extra-key]
+					priority: 10
 			v1-public-keys:
 				extra-key:
 					id: ` + extraTestKey.ID + `
@@ -907,14 +931,13 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "foo",
-
 		Archives: map[string]*setup.Archive{
 			"foo": {
 				Name:       "foo",
 				Version:    "22.04",
 				Suites:     []string{"jammy"},
 				Components: []string{"main", "universe"},
+				Priority:   20,
 				PubKeys:    []*packet.PublicKey{extraTestKey.PubKey},
 			},
 			"bar": {
@@ -922,15 +945,15 @@ var setupTests = []setupTest{{
 				Version:    "22.04",
 				Suites:     []string{"jammy-updates"},
 				Components: []string{"universe"},
+				Priority:   10,
 				PubKeys:    []*packet.PublicKey{testKey.PubKey, extraTestKey.PubKey},
 			},
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "foo",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
-				Slices:  map[string]*setup.Slice{},
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
 			},
 		},
 	},
@@ -944,7 +967,6 @@ var setupTests = []setupTest{{
 					version: 22.04
 					components: [main, universe]
 					suites: [jammy]
-					default: true
 		`,
 	},
 	relerror: `chisel.yaml: archive "foo" missing v1-public-keys field`,
@@ -959,7 +981,6 @@ var setupTests = []setupTest{{
 					components: [main, universe]
 					suites: [jammy]
 					v1-public-keys: [extra-key]
-					default: true
 		`,
 		"slices/mydir/mypkg.yaml": `
 			package: mypkg
@@ -977,7 +998,6 @@ var setupTests = []setupTest{{
 					components: [main, universe]
 					suites: [jammy]
 					v1-public-keys: [extra-key]
-					default: true
 			v1-public-keys:
 				extra-key:
 					id: foo
@@ -1005,7 +1025,6 @@ var setupTests = []setupTest{{
 					components: [main, universe]
 					suites: [jammy]
 					v1-public-keys: [extra-key]
-					default: true
 			v1-public-keys:
 				extra-key:
 					id: ` + extraTestKey.ID + `
@@ -1028,8 +1047,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1041,9 +1058,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"jq": {
-				Archive: "ubuntu",
-				Name:    "jq",
-				Path:    "slices/mydir/jq.yaml",
+				Name: "jq",
+				Path: "slices/mydir/jq.yaml",
 				Slices: map[string]*setup.Slice{
 					"bins": {
 						Package: "jq",
@@ -1082,7 +1098,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1094,9 +1109,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"slice1": {
 						Package: "mypkg",
@@ -1151,8 +1165,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1164,9 +1176,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"slice1": {
 						Package: "mypkg",
@@ -1187,9 +1198,8 @@ var setupTests = []setupTest{{
 				},
 			},
 			"myotherpkg": {
-				Archive: "ubuntu",
-				Name:    "myotherpkg",
-				Path:    "slices/mydir/myotherpkg.yaml",
+				Name: "myotherpkg",
+				Path: "slices/mydir/myotherpkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"slice1": {
 						Package: "myotherpkg",
@@ -1312,6 +1322,15 @@ var setupTests = []setupTest{{
 	},
 	relerror: `slices test-package_myslice1 and test-package_myslice2 conflict on /dir/\*\* and /dir/file`,
 }, {
+	summary: "Pinned archive is not defined",
+	input: map[string]string{
+		"slices/test-package.yaml": `
+			package: test-package
+			archive: non-existing
+		`,
+	},
+	relerror: `slices/test-package.yaml: package refers to undefined archive "non-existing"`,
+}, {
 	summary: "Specify generate: manifest",
 	input: map[string]string{
 		"slices/mydir/mypkg.yaml": `
@@ -1323,8 +1342,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1336,9 +1353,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -1373,8 +1389,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1386,9 +1400,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -1465,8 +1478,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	release: &setup.Release{
-		DefaultArchive: "ubuntu",
-
 		Archives: map[string]*setup.Archive{
 			"ubuntu": {
 				Name:       "ubuntu",
@@ -1478,9 +1489,8 @@ var setupTests = []setupTest{{
 		},
 		Packages: map[string]*setup.Package{
 			"mypkg": {
-				Archive: "ubuntu",
-				Name:    "mypkg",
-				Path:    "slices/mydir/mypkg.yaml",
+				Name: "mypkg",
+				Path: "slices/mydir/mypkg.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg",
@@ -1492,9 +1502,8 @@ var setupTests = []setupTest{{
 				},
 			},
 			"mypkg2": {
-				Archive: "ubuntu",
-				Name:    "mypkg2",
-				Path:    "slices/mydir/mypkg2.yaml",
+				Name: "mypkg2",
+				Path: "slices/mydir/mypkg2.yaml",
 				Slices: map[string]*setup.Slice{
 					"myslice": {
 						Package: "mypkg2",
@@ -1562,6 +1571,45 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `slice mypkg_myslice path /path/\*\* has invalid generate options`,
+}, {
+	summary: "Default archive is deprecated and ignored",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: chisel-v1
+			archives:
+				ubuntu:
+					default: true
+					version: 22.04
+					components: [main]
+					suites: [jammy]
+					v1-public-keys: [test-key]
+			v1-public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "22.04",
+				Suites:     []string{"jammy"},
+				Components: []string{"main"},
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
+			},
+		},
+	},
 }}
 
 var defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -824,7 +824,7 @@ var setupTests = []setupTest{{
 			package: mypkg
 		`,
 	},
-	relerror: `chisel.yaml: archive "bar" missing priority`,
+	relerror: `chisel.yaml: archive "bar" is missing the priority setting`,
 }, {
 	summary: "Multiple archives with no priorities",
 	input: map[string]string{
@@ -850,7 +850,7 @@ var setupTests = []setupTest{{
 			package: mypkg
 		`,
 	},
-	relerror: `chisel.yaml: archives "bar" and "foo" have the same priority value of 0`,
+	relerror: `chisel.yaml: archive "bar" is missing the priority setting`,
 }, {
 	summary: "Archive with suites unset",
 	input: map[string]string{
@@ -910,6 +910,25 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `chisel.yaml: archive "foo" has invalid priority value of 10000`,
+}, {
+	summary: "Invalid archive priority of 0",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					priority: 0
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+	},
+	relerror: `chisel.yaml: archive "foo" has invalid priority value of 0`,
 }, {
 	summary: "Extra fields in YAML are ignored (necessary for forward compatibility)",
 	input: map[string]string{
@@ -1693,7 +1712,7 @@ var setupTests = []setupTest{{
 				Suites:     []string{"jammy"},
 				Components: []string{"main"},
 				PubKeys:    []*packet.PublicKey{testKey.PubKey},
-				Priority:   0,
+				Priority:   1,
 			},
 			"other-1": {
 				Name:       "other-1",

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -799,6 +799,59 @@ var setupTests = []setupTest{{
 		},
 	},
 }, {
+	summary: "Multiple archives inconsistent use of priorities",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					priority: 20
+					public-keys: [test-key]
+				bar:
+					version: 22.04
+					components: [universe]
+					suites: [jammy-updates]
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	relerror: `chisel.yaml: archive "bar" missing priority`,
+}, {
+	summary: "Multiple archives with no priorities",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				foo:
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					public-keys: [test-key]
+				bar:
+					version: 22.04
+					components: [universe]
+					suites: [jammy-updates]
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	relerror: `chisel.yaml: archives "bar" and "foo" have the same priority value of 0`,
+}, {
 	summary: "Archive with suites unset",
 	input: map[string]string{
 		"chisel.yaml": `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1749,7 +1749,7 @@ var setupTests = []setupTest{{
 			package: mypkg
 		`,
 	},
-	relerror: `chisel.yaml: more than one default archive: foo, bar`,
+	relerror: `chisel.yaml: more than one default archive: bar, foo`,
 }}
 
 var defaultChiselYaml = `

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -86,7 +86,7 @@ func Run(options *RunOptions) error {
 		targetDir = filepath.Join(dir, targetDir)
 	}
 
-	pkgToArchive, err := selectPkgArchives(options.Archives, options.Selection)
+	pkgArchive, err := selectPkgArchives(options.Archives, options.Selection)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func Run(options *RunOptions) error {
 			extractPackage = make(map[string][]deb.ExtractInfo)
 			extract[slice.Package] = extractPackage
 		}
-		arch := pkgToArchive[slice.Package].Options().Arch
+		arch := pkgArchive[slice.Package].Options().Arch
 		copyrightPath := "/usr/share/doc/" + slice.Package + "/copyright"
 		hasCopyright := false
 		for targetPath, pathInfo := range slice.Contents {
@@ -151,7 +151,7 @@ func Run(options *RunOptions) error {
 		if packages[slice.Package] != nil {
 			continue
 		}
-		reader, info, err := pkgToArchive[slice.Package].Fetch(slice.Package)
+		reader, info, err := pkgArchive[slice.Package].Fetch(slice.Package)
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ func Run(options *RunOptions) error {
 	// them to the appropriate slices.
 	relPaths := map[string][]*setup.Slice{}
 	for _, slice := range options.Selection.Slices {
-		arch := pkgToArchive[slice.Package].Options().Arch
+		arch := pkgArchive[slice.Package].Options().Arch
 		for relPath, pathInfo := range slice.Contents {
 			if len(pathInfo.Arch) > 0 && !slices.Contains(pathInfo.Arch, arch) {
 				continue
@@ -482,9 +482,9 @@ func selectPkgArchives(archives map[string]archive.Archive, selection *setup.Sel
 		return b.Priority - a.Priority
 	})
 
-	pkgToArchive := make(map[string]archive.Archive)
+	pkgArchive := make(map[string]archive.Archive)
 	for _, s := range selection.Slices {
-		if _, ok := pkgToArchive[s.Package]; ok {
+		if _, ok := pkgArchive[s.Package]; ok {
 			continue
 		}
 		pkg := selection.Release.Packages[s.Package]
@@ -509,7 +509,7 @@ func selectPkgArchives(archives map[string]archive.Archive, selection *setup.Sel
 		if chosen == nil {
 			return nil, fmt.Errorf("cannot find package %q in archive(s)", pkg.Name)
 		}
-		pkgToArchive[pkg.Name] = chosen
+		pkgArchive[pkg.Name] = chosen
 	}
-	return pkgToArchive, nil
+	return pkgArchive, nil
 }

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -86,7 +86,7 @@ func Run(options *RunOptions) error {
 		targetDir = filepath.Join(dir, targetDir)
 	}
 
-	archives, err := selectPkgArchives(options.Archives, options.Selection)
+	pkgToArchive, err := selectPkgArchives(options.Archives, options.Selection)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func Run(options *RunOptions) error {
 			extractPackage = make(map[string][]deb.ExtractInfo)
 			extract[slice.Package] = extractPackage
 		}
-		arch := archives[slice.Package].Options().Arch
+		arch := pkgToArchive[slice.Package].Options().Arch
 		copyrightPath := "/usr/share/doc/" + slice.Package + "/copyright"
 		hasCopyright := false
 		for targetPath, pathInfo := range slice.Contents {
@@ -151,7 +151,7 @@ func Run(options *RunOptions) error {
 		if packages[slice.Package] != nil {
 			continue
 		}
-		reader, info, err := archives[slice.Package].Fetch(slice.Package)
+		reader, info, err := pkgToArchive[slice.Package].Fetch(slice.Package)
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ func Run(options *RunOptions) error {
 	// them to the appropriate slices.
 	relPaths := map[string][]*setup.Slice{}
 	for _, slice := range options.Selection.Slices {
-		arch := archives[slice.Package].Options().Arch
+		arch := pkgToArchive[slice.Package].Options().Arch
 		for relPath, pathInfo := range slice.Contents {
 			if len(pathInfo.Arch) > 0 && !slices.Contains(pathInfo.Arch, arch) {
 				continue
@@ -482,9 +482,9 @@ func selectPkgArchives(archives map[string]archive.Archive, selection *setup.Sel
 		return b.Priority - a.Priority
 	})
 
-	pkgArchives := make(map[string]archive.Archive)
+	pkgToArchive := make(map[string]archive.Archive)
 	for _, s := range selection.Slices {
-		if _, ok := pkgArchives[s.Package]; ok {
+		if _, ok := pkgToArchive[s.Package]; ok {
 			continue
 		}
 		pkg := selection.Release.Packages[s.Package]
@@ -509,7 +509,7 @@ func selectPkgArchives(archives map[string]archive.Archive, selection *setup.Sel
 		if chosen == nil {
 			return nil, fmt.Errorf("cannot find package %q in archive(s)", pkg.Name)
 		}
-		pkgArchives[pkg.Name] = chosen
+		pkgToArchive[pkg.Name] = chosen
 	}
-	return pkgArchives, nil
+	return pkgToArchive, nil
 }

--- a/internal/testutil/archive.go
+++ b/internal/testutil/archive.go
@@ -10,15 +10,16 @@ import (
 
 type TestArchive struct {
 	Opts     archive.Options
-	Packages map[string]TestPackage
+	Packages map[string]*TestPackage
 }
 
 type TestPackage struct {
-	Name    string
-	Version string
-	Hash    string
-	Arch    string
-	Data    []byte
+	Name     string
+	Version  string
+	Hash     string
+	Arch     string
+	Data     []byte
+	Archives []string
 }
 
 func (a *TestArchive) Options() *archive.Options {


### PR DESCRIPTION
This commit adds support for fetching packages from multiple archives. It introduces a new field `archives.<archive-name>.priority` which takes in a signed integer and specifies the priority of a certain archive. A package is fetched from the archive with highest priority and negative priorities are ignored unless explicitly pinned in a package.

The concept of default archive in chisel.yaml is now deprecated. However, the field can still be present and it will be parsed but IGNORED.

DEPRECATED: "archives.<archive>.default" field in chisel.yaml.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
