### PR TITLE
feat: make suites mandatory in archive config

### DIFF
--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -153,6 +153,7 @@ var defaultChiselYaml = `
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
+			suites: [jammy]
 			v1-public-keys: [test-key]
 	v1-public-keys:
 		test-key:

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -481,13 +481,6 @@ type yamlPubKey struct {
 	Armor string `yaml:"armor"`
 }
 
-var ubuntuAdjectives = map[string]string{
-	"18.04": "bionic",
-	"20.04": "focal",
-	"22.04": "jammy",
-	"22.10": "kinetic",
-}
-
 func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 	release := &Release{
 		Path:     baseDir,
@@ -538,11 +531,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			return nil, fmt.Errorf("%s: archive %q missing version field", fileName, archiveName)
 		}
 		if len(details.Suites) == 0 {
-			adjective := ubuntuAdjectives[details.Version]
-			if adjective == "" {
-				return nil, fmt.Errorf("%s: archive %q missing suites field", fileName, archiveName)
-			}
-			details.Suites = []string{adjective}
+			return nil, fmt.Errorf("%s: archive %q missing suites field", fileName, archiveName)
 		}
 		if len(details.Components) == 0 {
 			return nil, fmt.Errorf("%s: archive %q missing components field", fileName, archiveName)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -820,6 +820,18 @@ var setupTests = []setupTest{{
 		},
 	},
 }, {
+	summary: "Archive with suites unset",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				ubuntu:
+					version: 22.04
+					components: [main, other]
+		`,
+	},
+	relerror: `chisel.yaml: archive "ubuntu" missing suites field`,
+}, {
 	summary: "Extra fields in YAML are ignored (necessary for forward compatibility)",
 	input: map[string]string{
 		"chisel.yaml": `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1570,6 +1570,7 @@ var defaultChiselYaml = `
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
+			suites: [jammy]
 			v1-public-keys: [test-key]
 	v1-public-keys:
 		test-key:

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -764,11 +764,13 @@ var slicerTests = []slicerTest{{
 				foo:
 					version: 22.04
 					components: [main, universe]
+					suites: [jammy]
 					default: true
 					v1-public-keys: [test-key]
 				bar:
 					version: 22.04
 					components: [main]
+					suites: [jammy]
 					v1-public-keys: [test-key]
 			v1-public-keys:
 				test-key:
@@ -1059,6 +1061,7 @@ var defaultChiselYaml = `
 		ubuntu:
 			version: 22.04
 			components: [main, universe]
+			suites: [jammy]
 			v1-public-keys: [test-key]
 	v1-public-keys:
 		test-key:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR makes the `suites` attribute of archives in the `chisel.yaml` mandatory. All other attributes are already mandatory (version, components and keys).
There was an old fallback logic which would set `suites` to the release adjective if left unset, but this logic was only configured for 4 ubuntu releases, one of which (bionic) is no longer supported by chisel, and all other three have their suites properly configured in their `chisel.yaml` already, so this piece of logic never triggers ([focal](https://github.com/canonical/chisel-releases/blob/ubuntu-20.04/chisel.yaml), [jammy](https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/chisel.yaml), [kinetic](https://github.com/canonical/chisel-releases/blob/ubuntu-22.10/chisel.yaml)).
