### PR TITLE
fix: info supports "generate" paths

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -820,10 +820,11 @@ func Select(release *Release, slices []SliceKey) (*Selection, error) {
 // The returned object takes pointers to the given PathInfo object.
 func pathInfoToYAML(pi *PathInfo) (*yamlPath, error) {
 	path := &yamlPath{
-		Mode:    yamlMode(pi.Mode),
-		Mutable: pi.Mutable,
-		Until:   pi.Until,
-		Arch:    yamlArch{List: pi.Arch},
+		Mode:     yamlMode(pi.Mode),
+		Mutable:  pi.Mutable,
+		Until:    pi.Until,
+		Arch:     yamlArch{List: pi.Arch},
+		Generate: pi.Generate,
 	}
 	switch pi.Kind {
 	case DirPath:
@@ -834,8 +835,8 @@ func pathInfoToYAML(pi *PathInfo) (*yamlPath, error) {
 		path.Text = &pi.Info
 	case SymlinkPath:
 		path.Symlink = pi.Info
-	case GlobPath:
-		// Nothing more needs to be done for this type.
+	case GlobPath, GeneratePath:
+		// Nothing more needs to be done for these types.
 	default:
 		return nil, fmt.Errorf("internal error: unrecognised PathInfo type: %s", pi.Kind)
 	}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1716,6 +1716,7 @@ func (s *S) TestPackageYAMLFormat(c *C) {
 							/dir/copy: {copy: /dir/file}
 							/dir/empty-file: {text: ""}
 							/dir/glob*: {}
+							/dir/manifest/**: {generate: manifest}
 							/dir/mutable: {text: TODO, mutable: true, arch: riscv64}
 							/dir/other-file: {}
 							/dir/sub-dir/: {make: true, mode: 0644}


### PR DESCRIPTION
Currently, the info command does not support the "generate" keyword in paths. This is a bug.

    $ chisel info --release ubuntu-24.04 base-files_chisel
    2024/10/07 08:47:57 Consulting release repository...
    2024/10/07 08:47:57 Cached ubuntu-24.04 release is still up-to-date.
    2024/10/07 08:47:57 Processing ubuntu-24.04 release...
    error: internal error: unrecognised PathInfo type: generate

This PR fixes the said bug and adds support for "generate"-kind paths in the info command.
