### PR TITLE
bugfix: explicit parents override implicit

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -247,11 +247,12 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			}
 			// Create the entry itself.
 			createOptions := &fsutil.CreateOptions{
-				Path:        filepath.Join(options.TargetDir, targetPath),
-				Mode:        tarHeader.FileInfo().Mode(),
-				Data:        pathReader,
-				Link:        tarHeader.Linkname,
-				MakeParents: true,
+				Path:         filepath.Join(options.TargetDir, targetPath),
+				Mode:         tarHeader.FileInfo().Mode(),
+				Data:         pathReader,
+				Link:         tarHeader.Linkname,
+				MakeParents:  true,
+				OverrideMode: true,
 			}
 			err := options.Create(extractInfos, createOptions)
 			if err != nil {

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -2,6 +2,8 @@ package deb_test
 
 import (
 	"bytes"
+	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,7 +19,7 @@ type extractTest struct {
 	summary string
 	pkgdata []byte
 	options deb.ExtractOptions
-	hackopt func(o *deb.ExtractOptions)
+	hackopt func(c *C, o *deb.ExtractOptions)
 	result  map[string]string
 	// paths which the extractor did not create explicitly.
 	notCreated []string
@@ -98,7 +100,7 @@ var extractTests = []extractTest{{
 		"/dir/several/levels/deep/file": "file 0644 6bc26dff",
 		"/other-dir/":                   "dir 0755",
 	},
-	hackopt: func(o *deb.ExtractOptions) {
+	hackopt: func(c *C, o *deb.ExtractOptions) {
 		o.Create = nil
 	},
 }, {
@@ -352,6 +354,25 @@ var extractTests = []extractTest{{
 		},
 	},
 	error: `cannot extract from package "test-package": path /dir/ requested twice with diverging mode: 0777 != 0000`,
+}, {
+	summary: "Explicit extraction overrides existing file",
+	pkgdata: testutil.PackageData["test-package"],
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/dir/": []deb.ExtractInfo{{
+				Path: "/dir/",
+				Mode: 0777,
+			}},
+		},
+	},
+	hackopt: func(c *C, o *deb.ExtractOptions) {
+		err := os.Mkdir(path.Join(o.TargetDir, "/dir"), 0666)
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		"/dir/": "dir 0777",
+	},
+	notCreated: []string{},
 }}
 
 func (s *S) TestExtract(c *C) {
@@ -374,7 +395,7 @@ func (s *S) TestExtract(c *C) {
 		}
 
 		if test.hackopt != nil {
-			test.hackopt(&options)
+			test.hackopt(c, &options)
 		}
 
 		err := deb.Extract(bytes.NewBuffer(test.pkgdata), &options)

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -19,8 +19,8 @@ type CreateOptions struct {
 	// If MakeParents is true, missing parent directories of Path are
 	// created with permissions 0755.
 	MakeParents bool
-	// For the mode to be updated if the entry already exists, OverrideMode has
-	// to be set to true. It does not affect symlinks.
+	// If OverrideMode is true and entry already exists, update the mode. Does
+	// not affect symlinks.
 	OverrideMode bool
 }
 

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -136,6 +136,24 @@ var createTests = []createTest{{
 	},
 }, {
 	options: fsutil.CreateOptions{
+		Path:         "foo",
+		Link:         "./bar",
+		Mode:         0776 | fs.ModeSymlink,
+		OverrideMode: true,
+	},
+	hackdir: func(c *C, dir string) {
+		err := os.WriteFile(filepath.Join(dir, "bar"), []byte("data"), 0666)
+		c.Assert(err, IsNil)
+		err = os.WriteFile(filepath.Join(dir, "foo"), []byte("data"), 0666)
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		"/foo": "symlink ./bar",
+		// mode is not updated.
+		"/bar": "file 0666 3a6eb079",
+	},
+}, {
+	options: fsutil.CreateOptions{
 		Path: "bar",
 		// Existing link with different target.
 		Link: "other",

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -93,6 +93,75 @@ var createTests = []createTest{{
 		// mode is not updated.
 		"/foo": "file 0666 d67e2e94",
 	},
+}, {
+	options: fsutil.CreateOptions{
+		Path:         "foo",
+		Mode:         fs.ModeDir | 0775,
+		OverrideMode: true,
+	},
+	hackdir: func(c *C, dir string) {
+		c.Assert(os.Mkdir(filepath.Join(dir, "foo/"), fs.ModeDir|0765), IsNil)
+	},
+	result: map[string]string{
+		// mode is updated.
+		"/foo/": "dir 0775",
+	},
+}, {
+	options: fsutil.CreateOptions{
+		Path:         "foo",
+		Mode:         0775,
+		Data:         bytes.NewBufferString("whatever"),
+		OverrideMode: true,
+	},
+	hackdir: func(c *C, dir string) {
+		err := os.WriteFile(filepath.Join(dir, "foo"), []byte("data"), 0666)
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		// mode is updated.
+		"/foo": "file 0775 85738f8f",
+	},
+}, {
+	options: fsutil.CreateOptions{
+		Path: "foo",
+		Link: "./bar",
+		Mode: 0666 | fs.ModeSymlink,
+	},
+	hackdir: func(c *C, dir string) {
+		err := os.WriteFile(filepath.Join(dir, "foo"), []byte("data"), 0666)
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		"/foo": "symlink ./bar",
+	},
+}, {
+	options: fsutil.CreateOptions{
+		Path: "bar",
+		// Existing link with different target.
+		Link: "other",
+		Mode: 0666 | fs.ModeSymlink,
+	},
+	hackdir: func(c *C, dir string) {
+		err := os.Symlink("foo", filepath.Join(dir, "bar"))
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		"/bar": "symlink other",
+	},
+}, {
+	options: fsutil.CreateOptions{
+		Path: "bar",
+		// Existing link with same target.
+		Link: "foo",
+		Mode: 0666 | fs.ModeSymlink,
+	},
+	hackdir: func(c *C, dir string) {
+		err := os.Symlink("foo", filepath.Join(dir, "bar"))
+		c.Assert(err, IsNil)
+	},
+	result: map[string]string{
+		"/bar": "symlink foo",
+	},
 }}
 
 func (s *S) TestCreate(c *C) {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -320,33 +320,33 @@ var slicerTests = []slicerTest{{
 		"/file":     "file 0644 fc02ca0e {other-package_myslice}",
 	},
 }, {
-	summary: "Install two packages, explicit path has preference over implicit parent",
+	summary: "Install two packages, explicit path has preference over implicit parent (alphabetical order)",
 	slices: []setup.SliceKey{
-		{"implicit-parent", "myslice"},
-		{"explicit-dir", "myslice"}},
+		{"a-implicit-parent", "myslice"},
+		{"b-explicit-dir", "myslice"}},
 	pkgs: map[string]testutil.TestPackage{
-		"implicit-parent": {
+		"a-implicit-parent": {
 			Data: testutil.MustMakeDeb([]testutil.TarEntry{
 				testutil.Dir(0755, "./dir/"),
 				testutil.Reg(0644, "./dir/file", "random"),
 			}),
 		},
-		"explicit-dir": {
+		"b-explicit-dir": {
 			Data: testutil.MustMakeDeb([]testutil.TarEntry{
 				testutil.Dir(01777, "./dir/"),
 			}),
 		},
 	},
 	release: map[string]string{
-		"slices/mydir/implicit-parent.yaml": `
-			package: implicit-parent
+		"slices/mydir/a-implicit-parent.yaml": `
+			package: a-implicit-parent
 			slices:
 				myslice:
 					contents:
 						/dir/file:
 		`,
-		"slices/mydir/explicit-dir.yaml": `
-			package: explicit-dir
+		"slices/mydir/b-explicit-dir.yaml": `
+			package: b-explicit-dir
 			slices:
 				myslice:
 					contents:
@@ -358,8 +358,50 @@ var slicerTests = []slicerTest{{
 		"/dir/file": "file 0644 a441b15f",
 	},
 	manifestPaths: map[string]string{
-		"/dir/":     "dir 01777 {explicit-dir_myslice}",
-		"/dir/file": "file 0644 a441b15f {implicit-parent_myslice}",
+		"/dir/":     "dir 01777 {b-explicit-dir_myslice}",
+		"/dir/file": "file 0644 a441b15f {a-implicit-parent_myslice}",
+	},
+}, {
+	summary: "Install two packages, explicit path has preference over implicit parent (reverse order)",
+	slices: []setup.SliceKey{
+		{"b-implicit-parent", "myslice"},
+		{"a-explicit-dir", "myslice"}},
+	pkgs: map[string]testutil.TestPackage{
+		"b-implicit-parent": {
+			Data: testutil.MustMakeDeb([]testutil.TarEntry{
+				testutil.Dir(0755, "./dir/"),
+				testutil.Reg(0644, "./dir/file", "random"),
+			}),
+		},
+		"a-explicit-dir": {
+			Data: testutil.MustMakeDeb([]testutil.TarEntry{
+				testutil.Dir(01777, "./dir/"),
+			}),
+		},
+	},
+	release: map[string]string{
+		"slices/mydir/b-implicit-parent.yaml": `
+			package: b-implicit-parent
+			slices:
+				myslice:
+					contents:
+						/dir/file:
+		`,
+		"slices/mydir/a-explicit-dir.yaml": `
+			package: a-explicit-dir
+			slices:
+				myslice:
+					contents:
+						/dir/:
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/":     "dir 01777",
+		"/dir/file": "file 0644 a441b15f",
+	},
+	manifestPaths: map[string]string{
+		"/dir/":     "dir 01777 {a-explicit-dir_myslice}",
+		"/dir/file": "file 0644 a441b15f {b-implicit-parent_myslice}",
 	},
 }, {
 	summary: "Valid same file in two slices in different packages",


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
This commits introduces a new flag for `fsutil.Create` called `OverrideMode` which updates the mode of existing entries. It is used to ensure that the explicit folder overrides the permissions of the implicit ones.