### PR TITLE
feat: support "Pro" archives

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,6 +27,8 @@ jobs:
           go-version: '>=1.17.0'
 
       - name: Build and run spread
+        env:
+          PRO_TOKEN: ${{ secrets.PRO_TOKEN }}
         run: |
           (cd _spread/cmd/spread && go build)
           _spread/cmd/spread/spread -v focal jammy mantic noble

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,3 +43,46 @@ jobs:
         with:
           name: chisel-test-coverage.html
           path: ./*.html
+
+  real-archive-tests:
+    # Do not change to newer releases as "fips" may not be available there.
+    runs-on: ubuntu-20.04
+    name: Real Archive Tests
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run real archive tests
+        env:
+          PRO_TOKEN: ${{ secrets.PRO_TOKEN }}
+        run: |
+          set -ex
+
+          detach() {
+            sudo pro detach --assume-yes || true
+            sudo rm -f /etc/apt/auth.conf.d/90ubuntu-advantage
+          }
+          trap detach EXIT
+
+          # Attach pro token and enable services
+          sudo pro attach ${PRO_TOKEN} --no-auto-enable
+
+          # Cannot enable fips and fips-updates at the same time.
+          # Hack: enable fips, copy the credentials and then after enabling
+          # other services, add the credentials back.
+          sudo pro enable fips --assume-yes
+          sudo cp /etc/apt/auth.conf.d/90ubuntu-advantage /etc/apt/auth.conf.d/90ubuntu-advantage.fips-creds
+          # This will disable the fips service.
+          sudo pro enable fips-updates esm-apps esm-infra --assume-yes
+          # Add the fips credentials back.
+          sudo sh -c 'cat /etc/apt/auth.conf.d/90ubuntu-advantage.fips-creds >> /etc/apt/auth.conf.d/90ubuntu-advantage'
+          sudo rm /etc/apt/auth.conf.d/90ubuntu-advantage.fips-creds
+
+          # Make apt credentials accessible to USER.
+          sudo setfacl -m u:$USER:r /etc/apt/auth.conf.d/90ubuntu-advantage
+
+          # Run tests on Pro and non-Pro real archives.
+          go test ./internal/archive/ -v --real-archive --real-pro-archive

--- a/README.md
+++ b/README.md
@@ -67,6 +67,48 @@ provided packages and install only the desired slices into the *myrootfs*
 folder, according to the slice definitions available in the
 ["ubuntu-22.04" chisel-releases branch](<https://github.com/canonical/chisel-releases/tree/ubuntu-22.04>).
 
+## Chisel support for Pro archives
+
+Chisel can also fetch and install packages from Ubuntu Pro archives. For this,
+the archive has to be defined with the `archives.<archive>.pro` field in
+chisel.yaml and its credentials have to be made available to Chisel.
+
+
+```yaml
+# chisel.yaml
+format: v1
+archives:
+  <archive-name>:
+    pro: <value>
+    ...
+...
+```
+
+Chisel currently supports the following Pro archives:
+
+| `pro` value | Archive URL | Related Ubuntu Pro service |
+| - | - | - |
+| fips         | https://esm.ubuntu.com/fips/ubuntu         | fips         |
+| fips-updates | https://esm.ubuntu.com/fips-updates/ubuntu | fips-updates |
+| apps         | https://esm.ubuntu.com/apps/ubuntu         | esm-apps     |
+| infra        | https://esm.ubuntu.com/infra/ubuntu        | esm-infra    |
+
+Authentication to Pro archives requires that the host is Pro or it is equipped
+with the Pro credentials. By default, Chisel will support using credentials
+from the `/etc/apt/auth.conf.d/` directory, but this location can be configured
+using the environment variable `CHISEL_AUTH_DIR`. Note that Chisel must have
+read permission for the necessary credentials files.
+
+The format of the files is documented in the
+[apt_auth.conf(5)](https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html)
+man page. Below is a snippet of the `/etc/apt/auth.conf.d/90ubuntu-advantage`
+file from a host with the `fips-updates` and `infra` archives enabled:
+
+```
+machine esm.ubuntu.com/infra/ubuntu/ login bearer password <infra-token>
+machine esm.ubuntu.com/fips-updates/ubuntu/ login bearer password <fips-updates-token>
+```
+
 ## Reference
 
 ### Chisel releases

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -70,10 +70,15 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Arch:       cmd.Arch,
 			Suites:     archiveInfo.Suites,
 			Components: archiveInfo.Components,
+			Pro:        archiveInfo.Pro,
 			CacheDir:   cache.DefaultDir("chisel"),
 			PubKeys:    archiveInfo.PubKeys,
 		})
 		if err != nil {
+			if err == archive.ErrCredentialsNotFound {
+				logf("Ignoring archive %q (credentials not found)...", archiveName)
+				continue
+			}
 			return err
 		}
 		archives[archiveName] = openArchive

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -327,6 +327,7 @@ func run() error {
 	deb.SetLogger(log.Default())
 	setup.SetLogger(log.Default())
 	slicer.SetLogger(log.Default())
+	SetLogger(log.Default())
 
 	parser := Parser()
 	xtra, err := parser.Parse()

--- a/internal/archive/export_test.go
+++ b/internal/archive/export_test.go
@@ -19,3 +19,5 @@ type Credentials = credentials
 
 var FindCredentials = findCredentials
 var FindCredentialsInDir = findCredentialsInDir
+
+var ProArchiveInfo = proArchiveInfo

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1740,6 +1740,117 @@ var setupTests = []setupTest{{
 		},
 	},
 }, {
+	summary: "Pro values in archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				ubuntu:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 10
+					public-keys: [test-key]
+				fips:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					pro: fips
+					priority: 20
+					public-keys: [test-key]
+				fips-updates:
+					version: 20.04
+					components: [main]
+					suites: [focal-updates]
+					pro: fips-updates
+					priority: 21
+					public-keys: [test-key]
+				apps:
+					version: 20.04
+					components: [main]
+					suites: [focal-apps-security]
+					pro: apps
+					priority: 16
+					public-keys: [test-key]
+				infra:
+					version: 20.04
+					components: [main]
+					suites: [focal-infra-security]
+					pro: infra
+					priority: 15
+					public-keys: [test-key]
+				ignored:
+					version: 20.04
+					components: [main]
+					suites: [foo]
+					pro: unknown-value
+					priority: 10
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "20.04",
+				Suites:     []string{"focal"},
+				Components: []string{"main"},
+				Priority:   10,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+			"fips": {
+				Name:       "fips",
+				Version:    "20.04",
+				Suites:     []string{"focal"},
+				Components: []string{"main"},
+				Pro:        "fips",
+				Priority:   20,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+			"fips-updates": {
+				Name:       "fips-updates",
+				Version:    "20.04",
+				Suites:     []string{"focal-updates"},
+				Components: []string{"main"},
+				Pro:        "fips-updates",
+				Priority:   21,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+			"apps": {
+				Name:       "apps",
+				Version:    "20.04",
+				Suites:     []string{"focal-apps-security"},
+				Components: []string{"main"},
+				Pro:        "apps",
+				Priority:   16,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+			"infra": {
+				Name:       "infra",
+				Version:    "20.04",
+				Suites:     []string{"focal-infra-security"},
+				Components: []string{"main"},
+				Pro:        "infra",
+				Priority:   15,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
+			},
+		},
+	},
+}, {
 	summary: "Default is ignored",
 	input: map[string]string{
 		"chisel.yaml": `

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1445,6 +1445,29 @@ var slicerTests = []slicerTest{{
 					contents:
 		`,
 	},
+}, {
+	summary: "No valid archives defined due to invalid pro value",
+	slices:  []setup.SliceKey{{"test-package", "myslice"}},
+	release: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				invalid:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 10
+					public-keys: [test-key]
+					pro: unknown-value
+		`,
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+		`,
+	},
+	error: `cannot find package "test-package" in archive\(s\)`,
 }}
 
 var defaultChiselYaml = `
@@ -1537,6 +1560,7 @@ func (s *S) TestRun(c *C) {
 						Version:    setupArchive.Version,
 						Suites:     setupArchive.Suites,
 						Components: setupArchive.Components,
+						Pro:        setupArchive.Pro,
 						Arch:       test.arch,
 					},
 					Packages: pkgs,

--- a/internal/testutil/pgpkeys.go
+++ b/internal/testutil/pgpkeys.go
@@ -21,6 +21,18 @@ var PGPKeys = map[string]*PGPKeyData{
 		ID:          "871920D1991BC93C",
 		PubKeyArmor: pubKeyUbuntu2018Armor,
 	},
+	"key-ubuntu-fips-v1": {
+		ID:          "C1997C40EDE22758",
+		PubKeyArmor: pubKeyUbuntuFIPSv1Armor,
+	},
+	"key-ubuntu-apps": {
+		ID:          "AB01A101DB53907B",
+		PubKeyArmor: pubKeyUbuntuAppsArmor,
+	},
+	"key-ubuntu-esm-v2": {
+		ID:          "4067E40313CB4B13",
+		PubKeyArmor: pubKeyUbuntuESMv2Armor,
+	},
 	"key1": {
 		ID:           "854BAF1AA9D76600",
 		PubKeyArmor:  pubKey1Armor,
@@ -84,6 +96,111 @@ QEtz6DGy5zkRhR4pGSZn+dFET7PdAjEK84y7BdY4t+U1jcSIvBj0F2B7LwRL7xGp
 SpIKi/ekAXLs117bvFHaCvmUYN7JVp1GMmVFxhIdx6CFm3fxG8QjNb5tere/YqK+
 uOgcXny1UlwtCUzlrSaP
 =9AdM
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+// Ubuntu Federal Information Processing Standards Automatic Signing Key V1 <esm@canonical.com>.
+// ID: C1997C40EDE22758.
+// Useful to validate InRelease files from live archive.
+const pubKeyUbuntuFIPSv1Armor = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBFzZxGABEADSWmX0+K//0cosKPyr5m1ewmwWKjRo/KBPTyR8icHhbBWfFd8T
+DtYggvQHPU0YnKRcWits0et8JqSgZttNa28s7SaSUTBzfgzFJZgULAi/4i8u8TUj
++KH2zSoUX55NKC9aozba1cR66jM6O/BHXK5YoZzTpmiY1AHlIWAJ9s6cCClhnYMR
+zwxSZVbefcYFbVPX/dQw/FMvJVeZ2aQ18NDgMQciu786aYklMFowxWNs/eLLTqum
+cDHaw9UpKyhgfL/mkaIXuhYy6YRByYq1oOnJ5XffAOtovvCti1MvsPc0NDhPiGLf
+9Fd/GtnqHxzVDqZmtUXX50mGu4LnJoHgWRjml3mapDPStzFr7Xgbb0NnyflmxnfN
+kQcu2lFyXFfndWwg/RAOFdBPxBQhRK52uZiCfydKD7zCXz9YGm9xEK541EG0FrwA
+6Vk1xaFol/jI8MQdP1o3JySX0Pqva3IHF7FHWHmxrIPaJLIHi0IrFG6Fgmk4sQ2w
+XSc8kbxR+wYYKqIhBUZP0eb1jkFfvRVS6YvAy18xtw5pFD+VURdA0Uu5cotESfyz
+oHsQ5R7wzg76oV/mYukHGC0x8peqxiPwbyhGFAhG8eUR66iYZgGbzmNI+OJz2EUi
+UZJJXt4rnI1RVJLbhK9RjeobkOjf58Cm8RExlqJU16gy9saCMSiAqHx8swARAQAB
+tFxVYnVudHUgRmVkZXJhbCBJbmZvcm1hdGlvbiBQcm9jZXNzaW5nIFN0YW5kYXJk
+cyBBdXRvbWF0aWMgU2lnbmluZyBLZXkgVjEgPGVzbUBjYW5vbmljYWwuY29tPokC
+OAQTAQIAIgUCXNnEYAIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQwZl8
+QO3iJ1j4Vw//SawfmZi1GW+EUnuPqSz+zcmIKdx6AWZTe9/vSj6jgq4SYt//LAiD
+NQz3dn2m0m5AaCucza2BCixUBrNhMh66m+lXfTqymUtTIpWpu4L1WLUbPjQ+s3Ad
+xuF7S5wJtQrYmPvmZduZgg1wcb8eaqVltRJREpOP6sxcuqtvcfv4v4QYZ+iYd7eJ
+8fxPOiyJEOTQPTdPZahYTaUOIloN5pT6uVg03u59Kh4aHCYxlRorvuRBabdctCfA
+EBgomk4Us20Tv31dqlvMAiGKJqf1wdjhzlUmk4g/fOiRSNETKSC/VeUGH0fSbizl
+Gs7Mg60jChPKpwzB6Rb5Nv2/Aw/FlSkfFhMdCdfKjl8IWOMPmElTVJFyVx1mmURi
+3LgsloDFmJfebXefSFA7S8KLyBGlZJ/APaym64Ls12PUOjfh1Glie3E8KO66AGLo
+ID1dQnzRizuHxW80ET03dSjzTXHLSi+iFycmNAxo6gB3GyOQ8tlIHjo1FfDfNYDf
+qKic3Q0B9TvF6hqVRIcyePK4lN5YtRpVRdVj/jv8AqbzaIaVCP4k4nNrbaVx5zQf
+BWq2E9IH+vLZfPyiP+hwxswfrlU3mrXBpPStIxq41yXFwQiDnqgkhEVAcrYPjBnS
+T6s3+b+4HbAW6mbp4jEHUd/F1+iXz90T2WArrNIkMbmpChMuSyRN8Hc=
+=DWhM
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+// Ubuntu Apps Automatic Signing Key <esm@canonical.com>.
+// ID: AB01A101DB53907B.
+// Useful to validate InRelease files from live archive.
+const pubKeyUbuntuAppsArmor = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF3WVA4BEAC7MDr8HClfKptSd4VeB12Vy+Ao/4NpY2ITdkRed4vfh/4eBWWn
+3+in6So2ekweifACSxScB/M9zVObsI1cab7QPMkIiATNUfIyOEP7iNWLX4+AytM1
+LP3bZo8OpghnLZNstCGbiRUO4CDNmCI04DOPCu9EVEO4WWNuWIMRwCLShDSf7Cid
+J2fn2TT/7vsmA4eI3YnAne+u8g4X2zMHQFkHANhylB0lPyThXo5jaxHImzm4wf/2
+LF8f1Y1nRQObS2jcvYc3fm9B7iOGpyNAw3h6hrPKH5T9tY/ZoMtFHqn66J1CBSHb
+hDkEvA46X50su4yAHeSiEG/hMYG7SoHzmAsjEXnvkTIE41WhmxlidQnRs2uWy34U
+7VmOpaidWn3R99fNHYOtSOB6bpIvls8snWSQ63jcFXnt05nVZsp/Ixzl0Oqitynx
+DFwoxEwt3ZuCHwxbx2vZ+FiZXVFN7I0IyBDOEL6XS27FNaMCZ7Q/6z/ckdWto55E
+264OWf9lnw31bXFXHWSusRXWzD6FK8dqWgjtrWwRxlvF4jm688lqpjac6fFES3UK
+BhjyHXFGL/+HHZ9CNxlLYF5QnXq1mGR0Ykw975u8KoOFSLBqsx+1a21m6dfzujY7
+2Gq6Sju+9Yo1aOF+CNvTMYdRBoDL4sFj6VAmUsszMA5aAb+82pOCaDvGJQARAQAB
+tDVVYnVudHUgQXBwcyBBdXRvbWF0aWMgU2lnbmluZyBLZXkgPGVzbUBjYW5vbmlj
+YWwuY29tPokCOAQTAQIAIgUCXdZUDgIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgEC
+F4AACgkQqwGhAdtTkHuTOw/8Czv42TSpwHz+eNtl3ZFyxta9rR/qWC3h+vMu0R/l
+5KU3aQQOygWOoUcr1QTPSSg3v/H+v/8vqVq2UuUxSIfpMxBj2kIX2vqskv6Roez7
+xR8lVDa0a47z/NYMfKpxrEJxOLh/c7I6aAsa597bTqDHtucHL/22BvfUJJqw6jq1
+7SswP5lqKPBFz7x+E2hgfJE7Vn7h0ICm29FkWnOeTKfj8VwTAeKXKUI9Hw6+aqr9
+29Y2NdLsYZ57mpivRLNM9sBZoF3avP1pUC2k0IwP3dwh4AxUMXjRRPh173iXBfR2
+yAf1lWET/5+8dSBrfFIZSo+FF/EEBmqIVtJpHkq8+YxUbCLbkoikRi2kwrgyXLEn
+FqxSU2Ab0xurFHiHcJoCGVD38xjznO5cQl7H4K9+B/rFpTTowOHbOcFpKAzpYqB5
+8rnR1yRSsB33zac8xesUIfzYWRtLc5/VIb5mOkWlb62d8emILx2XuRFVjKq6mKki
+oGckhDUOuEFrjW1cQq+PWBBxyJoXcy6wGSoPJ/ELeaf9zg8SF0jwuN6BPHVBeJ/E
+W53zR5iV0N9fRT+M2JN5tc5HenO92xLgPAh+GPWLYmPdTmHu+kFozqsHx/NUw2iP
+PBL6Q1VZytt2Uf6qLPUx7GpYMKf42Vldb0feFo/YA/lzOgPlY29pDLKXbse6o+Sr
+kmk=
+=AEEr
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+// Ubuntu Extended Security Maintenance Automatic Signing Key v2 <esm@canonical.com>.
+// ID: 4067E40313CB4B13.
+// Useful to validate InRelease files from live archive.
+const pubKeyUbuntuESMv2Armor = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBFy2kH0BEADl/2e2pULZaSRovd3E1i1cVk3zebzndHZm/hK8/Srx69ivw3pY
+680gFE/N3s3R/C5Jh9ThdD1zpGmxVdqcABSPmW1FczdFZY2E37HMH7Uijs4CsnFs
+8nrNGQaqX/T1g2fQqjia3zkabMeehUEZC5GPYjpeeFW6Wy1O1A1Tzu7/Wjc+uF/t
+YYe/ZPXea74QZphu/N+8dy/ts/IzL2VtXuxiegGLfBFqzgZuBmlxXHVhftKvcis9
+t2ko65uVyDcLtItMhSJokKBsIYJliqOXjUbQf5dz8vLXkku94arBMgsxDWT4K/xI
+OTsaI/GMlSIKQ6Ucd/GKrBEsy5O8RDtD9A2klV7YeEwPEgqL+RhpdxAs/xUeTOZG
+JKwuvlBjzIhJF9bIfbyzx7DdcGFqRE+a8eBIUMQjVkt9Yk7jj0eV3oVTE7XNhb53
+rHuPL+zJVkiharxiTgYvkow3Nlbg3oURx9Ln67ni9pUtI1HbortGZsAkyOcpep58
+K9cYvUePJWzjkY+bjcGKR19CWPl7KaUalIf2Tao5OwtqjrblTsXdtV7eG45ys0MT
+Kl/DeqTJ0w6+i4eq4ZUfOCL/DIwS5zUB9j1KMUgEfocjYIdHWI8TSrA8jLYNPbVE
+6+WjekHMB9liNrEQoESWBddS+bglPxuVwy2paGTUYJW1GnRZOTD+CG4ETQARAQAB
+tFFVYnVudHUgRXh0ZW5kZWQgU2VjdXJpdHkgTWFpbnRlbmFuY2UgQXV0b21hdGlj
+IFNpZ25pbmcgS2V5IHYyIDxlc21AY2Fub25pY2FsLmNvbT6JAjgEEwECACIFAly2
+kH0CGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEEBn5AMTy0sTo/8QAJ1C
+NhAkZ+Xq/BZ8UzAFCQn6GlIYg/ueY216xcQdDX1uN8hNOlPTNmftroIvohFAfFtB
+m5galzY3DBPU8eZr8Y8XgiGD97wkR4zfhfh1EK/6diMG/HG00kdcWquFXMRB7E7S
+nDTpyuPfkAzm9n6l69UB3UA53CaEUuVJ7qFfZsWgiQeUJpvqD0MIVsWr+T/paSx7
+1JE9BVatFefq0egErv1sa2uYgcH9TRZMLw6gYxWtXeGA08Cpp0+OEvIzmJOHo5/F
+EpJ3hGk87Of77BC7FbqSDpeYkcjnlI2i0QAxxFygKhPOMLuA4XVn3TDuqCgTFIFC
+puupzIX/Up51FJmo64V9GZ/uF0jZy4tDxsCRJnEV+4Kv2sU5uMlmNchZMBjXYGiG
+tpH9CqJkSZjFvB6bk+Ot98KI6+CuNWn1N0sXFKpEUGdJLuOKfJ9+xI5plo8Bct5C
+DM9s4l0IuAPCsyayXrSmlyOAHzxDUeRMCEUnXWfycCUyqdyYIcCMPLV44Ccg9NyS
+89dEauSCPuyCSxm5UYEHQdsSI/+rxRdS9IzoKs4za2L7fhY8PfdPlmghmXc/chz1
+RtgjPfAsUHUPRr0h//TzxRm5dbYdUyqMPzZcDO8wYBT/4xrwnFkSHZhnVxpw7PDi
+JYK4SVVc4ZO20PE1+RZc5oSbt4hRbFTCSb31Pydc
+=KWLs
 -----END PGP PUBLIC KEY BLOCK-----
 `
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,8 @@ parts:
     override-build: |
       go generate ./cmd
       craftctl default
+    stage:
+      - -bin/chrorder
 
   chisel-release-data:
     plugin: nil
@@ -56,9 +58,17 @@ parts:
       craftctl set grade="$grade"
     after: [chisel]
 
+plugs:
+  pro-credentials:
+    interface: system-files
+    read:
+      - /etc/apt/auth.conf.d
+      - /etc/apt/auth.conf.d/90ubuntu-advantage
+
 apps:
   chisel:
     command: bin/chisel
     plugs:
       - network
       - home
+      - pro-credentials

--- a/spread.yaml
+++ b/spread.yaml
@@ -4,6 +4,7 @@ path: /chisel
 
 environment:
   OS: ubuntu
+  PRO_TOKEN: $(HOST:echo $PRO_TOKEN)
 
 backends:
   # Cannot use LXD backend due to https://github.com/snapcore/spread/issues/154

--- a/tests/pro-archives/chisel-releases/chisel.yaml
+++ b/tests/pro-archives/chisel-releases/chisel.yaml
@@ -1,0 +1,45 @@
+format: v1
+
+archives:
+  ubuntu:
+    version: 24.04
+    pro: infra
+    components: [main]
+    suites: [noble-infra-security, noble-infra-updates]
+    public-keys: [ubuntu-esm-key-v2]
+
+public-keys:
+  # Ubuntu Extended Security Maintenance Automatic Signing Key v2 <esm@canonical.com>
+  # rsa4096/56f7650a24c9e9ecf87c4d8d4067e40313cb4b13 2019-04-17T02:33:33Z
+  ubuntu-esm-key-v2:
+    id: "4067E40313CB4B13"
+    armor: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      mQINBFy2kH0BEADl/2e2pULZaSRovd3E1i1cVk3zebzndHZm/hK8/Srx69ivw3pY
+      680gFE/N3s3R/C5Jh9ThdD1zpGmxVdqcABSPmW1FczdFZY2E37HMH7Uijs4CsnFs
+      8nrNGQaqX/T1g2fQqjia3zkabMeehUEZC5GPYjpeeFW6Wy1O1A1Tzu7/Wjc+uF/t
+      YYe/ZPXea74QZphu/N+8dy/ts/IzL2VtXuxiegGLfBFqzgZuBmlxXHVhftKvcis9
+      t2ko65uVyDcLtItMhSJokKBsIYJliqOXjUbQf5dz8vLXkku94arBMgsxDWT4K/xI
+      OTsaI/GMlSIKQ6Ucd/GKrBEsy5O8RDtD9A2klV7YeEwPEgqL+RhpdxAs/xUeTOZG
+      JKwuvlBjzIhJF9bIfbyzx7DdcGFqRE+a8eBIUMQjVkt9Yk7jj0eV3oVTE7XNhb53
+      rHuPL+zJVkiharxiTgYvkow3Nlbg3oURx9Ln67ni9pUtI1HbortGZsAkyOcpep58
+      K9cYvUePJWzjkY+bjcGKR19CWPl7KaUalIf2Tao5OwtqjrblTsXdtV7eG45ys0MT
+      Kl/DeqTJ0w6+i4eq4ZUfOCL/DIwS5zUB9j1KMUgEfocjYIdHWI8TSrA8jLYNPbVE
+      6+WjekHMB9liNrEQoESWBddS+bglPxuVwy2paGTUYJW1GnRZOTD+CG4ETQARAQAB
+      tFFVYnVudHUgRXh0ZW5kZWQgU2VjdXJpdHkgTWFpbnRlbmFuY2UgQXV0b21hdGlj
+      IFNpZ25pbmcgS2V5IHYyIDxlc21AY2Fub25pY2FsLmNvbT6JAjgEEwECACIFAly2
+      kH0CGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEEBn5AMTy0sTo/8QAJ1C
+      NhAkZ+Xq/BZ8UzAFCQn6GlIYg/ueY216xcQdDX1uN8hNOlPTNmftroIvohFAfFtB
+      m5galzY3DBPU8eZr8Y8XgiGD97wkR4zfhfh1EK/6diMG/HG00kdcWquFXMRB7E7S
+      nDTpyuPfkAzm9n6l69UB3UA53CaEUuVJ7qFfZsWgiQeUJpvqD0MIVsWr+T/paSx7
+      1JE9BVatFefq0egErv1sa2uYgcH9TRZMLw6gYxWtXeGA08Cpp0+OEvIzmJOHo5/F
+      EpJ3hGk87Of77BC7FbqSDpeYkcjnlI2i0QAxxFygKhPOMLuA4XVn3TDuqCgTFIFC
+      puupzIX/Up51FJmo64V9GZ/uF0jZy4tDxsCRJnEV+4Kv2sU5uMlmNchZMBjXYGiG
+      tpH9CqJkSZjFvB6bk+Ot98KI6+CuNWn1N0sXFKpEUGdJLuOKfJ9+xI5plo8Bct5C
+      DM9s4l0IuAPCsyayXrSmlyOAHzxDUeRMCEUnXWfycCUyqdyYIcCMPLV44Ccg9NyS
+      89dEauSCPuyCSxm5UYEHQdsSI/+rxRdS9IzoKs4za2L7fhY8PfdPlmghmXc/chz1
+      RtgjPfAsUHUPRr0h//TzxRm5dbYdUyqMPzZcDO8wYBT/4xrwnFkSHZhnVxpw7PDi
+      JYK4SVVc4ZO20PE1+RZc5oSbt4hRbFTCSb31Pydc
+      =KWLs
+      -----END PGP PUBLIC KEY BLOCK-----

--- a/tests/pro-archives/chisel-releases/slices/hello.yaml
+++ b/tests/pro-archives/chisel-releases/slices/hello.yaml
@@ -1,0 +1,13 @@
+package: hello
+
+essential:
+  - hello_copyright
+
+slices:
+  bins:
+    contents:
+      /usr/bin/hello:
+
+  copyright:
+    contents:
+      /usr/share/doc/hello/copyright:

--- a/tests/pro-archives/task.yaml
+++ b/tests/pro-archives/task.yaml
@@ -1,0 +1,22 @@
+summary: Chisel can fetch packages from Ubuntu Pro archives
+
+variants:
+  - noble
+
+environment:
+  ROOTFS: rootfs
+
+prepare: |
+  apt update && apt install -y ubuntu-pro-client
+  pro attach ${PRO_TOKEN} --no-auto-enable
+  pro enable esm-infra --assume-yes
+  mkdir ${ROOTFS}
+
+restore: |
+  pro detach --assume-yes
+  rm -r ${ROOTFS}
+
+execute: |
+  chisel cut --release ./chisel-releases/ --root ${ROOTFS} hello_bins
+  test -f ${ROOTFS}/usr/bin/hello
+  test -f ${ROOTFS}/usr/share/doc/hello/copyright


### PR DESCRIPTION
In chisel.yaml, archive definitions can now use the "pro" value to specify Ubuntu Pro archives. The `archives.<archive>.pro` value currently accepts the following values: "fips", "fips-updates", "apps" and "infra". Any other values are ignored.

By default, Chisel will look for credentials in the `/etc/apt/auth.conf.d/` directory, unless the environment variable `CHISEL_AUTH_DIR` is set. In which case, it will look for configuration files in that directory. The configuration files may only have the ".conf" extensions or no extensions, the format is described in https://manpages.debian.org/testing/apt/apt_auth.conf.5.en.html.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
