### PR TITLE
feat: parallelism to speed up conflict search

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -481,7 +481,7 @@ var setupTests = []setupTest{{
 						/file/foob*r:
 		`,
 	},
-	relerror: `slices mypkg1_myslice and mypkg2_myslice conflict on /file/f\*obar and /file/foob\*r`,
+	relerror: `slices mypkg1_myslice and mypkg2_myslice conflict on (/file/f\*obar and /file/foob\*r)|(/file/foob\*r and /file/f\*obar)`,
 }, {
 	summary: "Conflicting globs and plain copies",
 	input: map[string]string{


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Right now all commands (info, find and cut) validate the release as a whole. For big releases such as ubuntu 24.04 this takes up the majority of the execution time. When looking at perf data it clearly shows that the bottleneck is strdist.GlobPath. In the past we already reduced the number of comparisons to a minimum and I have tried to optimize the code but nothing moves the needle. Because this task is CPU bounded and there are no low hanging fruits, the best approach is to parallelize the computation to all available CPUs.

This change halves the execution time for the commands and the tests in my computer with 4 logical CPUs.