### PR TITLE
fix: wrong help text for version command

### DIFF
--- a/cmd/chisel/cmd_version.go
+++ b/cmd/chisel/cmd_version.go
@@ -10,7 +10,7 @@ import (
 
 var shortVersionHelp = "Show version details"
 var longVersionHelp = `
-The version command displays the versions of the running client and server.
+Show the Chisel version and exit.
 `
 
 type cmdVersion struct{}


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Just a simple fix to correct the help information displayed for the `version` command.