### PR TITLE
chore(snap): rename system-files interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [chisel]
 
 plugs:
-  pro-credentials:
+  etc-apt-auth-conf-d:
     interface: system-files
     read:
       - /etc/apt/auth.conf.d
@@ -61,4 +61,4 @@ apps:
     plugs:
       - network
       - home
-      - pro-credentials
+      - etc-apt-auth-conf-d


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Simple renaming of the `system-files` interface, following the suggestion from https://forum.snapcraft.io/t/request-auto-connection-for-system-files-in-chisel/44542/2?u=cjdc