### PR TITLE
WIP docs: align README with new Chisel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Snap](https://github.com/canonical/chisel/actions/workflows/snap.yml/badge.svg?event=release)](https://github.com/canonical/chisel/actions/workflows/snap.yml)
 [![Build](https://github.com/canonical/chisel/actions/workflows/build.yml/badge.svg)](https://github.com/canonical/chisel/actions/workflows/build.yml)
 [![Tests](https://github.com/canonical/chisel/actions/workflows/tests.yaml/badge.svg)](https://github.com/canonical/chisel/actions/workflows/tests.yaml)
+[![Documentation Status](https://readthedocs.com/projects/canonical-chisel/badge/?version=latest)](https://canonical-chisel.readthedocs-hosted.com/en/latest/?badge=latest)
 
 # Chisel
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

**WIP**: some of the README's contents (e.g. the Pro example) are still missing from the [Chisel docs](https://canonical-chisel.readthedocs-hosted.com/en/latest/). Once we make sure the docs comprise everything that is in this README, we'll update this PR and significantly reduce this repo's README and point to the Chisel docs instead.