### PR TITLE
chore(ci): bump artifact actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           echo "ARCHIVE_FILE_SHA384=${ARCHIVE_FILE_SHA384}" >>$GITHUB_OUTPUT
 
       - name: Upload archive as Actions artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.archive.outputs.ARCHIVE_FILE }}
           path: |

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -27,7 +27,7 @@ jobs:
         uses: snapcore/action-build@v1
 
       - name: Attach chisel snap to GH workflow execution
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-chisel-snap.outputs.snap }}
           path: ${{ steps.build-chisel-snap.outputs.snap }}
@@ -40,7 +40,7 @@ jobs:
       chisel-version: ${{ steps.install-chisel-snap.outputs.version }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.chisel-snap }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Upload HTML test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Bumps `upload-artifact` and `download-artifact` actions to `v4`, as `v3` is deprecated.

Associated workflow run: https://github.com/canonical/chisel/actions/runs/12812400771/job/35723950707?pr=192#step:1:36

Ref: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
