### PR TITLE
chore(deps): bump go-lang to v1.23

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: Check bugs and unused code
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.1
+          version: v1.63.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/chisel
 
-go 1.21
+go 1.23
 
 require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -346,9 +346,7 @@ func fastValidate(options *WriteOptions) (err error) {
 			}
 		}
 		if entry.Inode != 0 {
-			// TODO remove the following line after upgrading to Go 1.22 or higher.
-			e := entry
-			hardLinkGroups[e.Inode] = append(hardLinkGroups[e.Inode], &e)
+			hardLinkGroups[entry.Inode] = append(hardLinkGroups[entry.Inode], &entry)
 		}
 	}
 	// Entries within a hard link group must have same content.

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -505,8 +505,6 @@ func sliceToYAML(s *Slice) (*yamlSlice, error) {
 		slice.Essential = append(slice.Essential, key.String())
 	}
 	for path, info := range s.Contents {
-		// TODO remove the following line after upgrading to Go 1.22 or higher.
-		info := info
 		yamlPath, err := pathInfoToYAML(&info)
 		if err != nil {
 			return nil, err

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s

--- a/spread.yaml
+++ b/spread.yaml
@@ -46,7 +46,10 @@ backends:
           password: ubuntu
 
 prepare: |
-  apt install -y golang git
+  apt install -y git wget
+  wget https://go.dev/dl/go1.23.5.linux-$(dpkg --print-architecture).tar.gz
+  tar -xf go1.23.5.linux-$(dpkg --print-architecture).tar.gz -C /usr/local
+  export PATH=$PATH:/usr/local/go/bin
   go build -buildvcs=false ./cmd/chisel/
   mv chisel /usr/local/bin
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

- This PR bumps the Golang version to 1.23 to fix the known exploited vulnerabilities (CVE-2024-34158 and CVE-2024-34156, and CVE-2024-34155, which is a medium vulnerability not listed as a KEV) in Golang v1.21.

- To accommodate the bumped Golang version, the [golangci-lint](https://github.com/golangci/golangci-lint) is bumped to `v1.63.4`.

- To accommodate the bumped Golang version, the Go binary is installed directly from `go.dev` in the spread test.