### PR TITLE
bugfix: revert disabling TopLevelControl

### DIFF
--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -24,7 +24,8 @@ type RunOptions struct {
 func Run(opts *RunOptions) error {
 	thread := &starlark.Thread{Name: opts.Label}
 	fileOptions := &syntax.FileOptions{
-		GlobalReassign: true,
+		TopLevelControl: true,
+		GlobalReassign:  true,
 	}
 	globals, err := starlark.ExecFileOptions(fileOptions, thread, opts.Label, opts.Script, opts.Namespace)
 	_ = globals

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -256,6 +256,13 @@ var scriptsTests = []scriptsTest{{
 		return nil
 	},
 	error: `no write: /foo/file2.txt`,
+}, {
+	summary: "Top level for loop is allowed",
+	script: `
+		for x in []:
+		    pass
+	`,
+	result: map[string]string{},
 }}
 
 func (s *S) TestScripts(c *C) {


### PR DESCRIPTION
TopLevelControl was disabled accidentally on #211. The old Starlark API had it enabled by default and the new one does not.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Bug found on chisel-releases CI when testing all packages against main ([action failure](https://github.com/canonical/chisel-releases/actions/runs/14238222496/job/39901906231?pr=509#step:8:1157)).
