### PR TITLE
Use modern Go constructs

### DIFF
--- a/cmd/chisel/log.go
+++ b/cmd/chisel/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {
@@ -55,7 +55,7 @@ func debugf(format string, args ...interface{}) {
 // panicf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, and then panics with the
 // same message.
-func panicf(format string, args ...interface{}) {
+func panicf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/apacheutil/log.go
+++ b/internal/apacheutil/log.go
@@ -35,7 +35,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -46,7 +46,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -348,16 +349,10 @@ func (index *ubuntuIndex) supportsArch(arch string) bool {
 
 func (index *ubuntuIndex) checkComponents(components []string) error {
 	releaseComponents := strings.Fields(index.release.Get("Components"))
-	for _, c1 := range components {
-		found := false
-		for _, c2 := range releaseComponents {
-			if c1 == c2 {
-				found = true
-				break
-			}
-		}
+	for _, c := range components {
+		found := slices.Contains(releaseComponents, c)
 		if !found {
-			return fmt.Errorf("archive has no component %q", c1)
+			return fmt.Errorf("archive has no component %q", c)
 		}
 	}
 	return nil

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type httpSuite struct {
-	logf      func(string, ...interface{})
+	logf      func(string, ...any)
 	base      string
 	request   *http.Request
 	requests  []*http.Request

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -119,7 +119,7 @@ func (s *httpSuite) prepareArchiveAdjustRelease(suite, version, arch string, com
 			Component: component,
 			Arch:      arch,
 		}
-		for j := 0; j < 2; j++ {
+		for j := range 2 {
 			seq := 1 + i*2 + j
 			index.Packages = append(index.Packages, &testarchive.Package{
 				Name:      fmt.Sprintf("mypkg%d", seq),

--- a/internal/archive/log.go
+++ b/internal/archive/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/deb/chrorder/main.go
+++ b/internal/deb/chrorder/main.go
@@ -59,9 +59,9 @@ func main() {
 	fmt.Fprintf(out, "package %v\n", pkgName)
 	fmt.Fprintf(out, "\n")
 	fmt.Fprintln(out, "var chOrder = [...]int{")
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		fmt.Fprintf(out, "\t")
-		for j := 0; j < 16; j++ {
+		for j := range 16 {
 			if j != 0 {
 				fmt.Fprintf(out, " ")
 			}

--- a/internal/deb/log.go
+++ b/internal/deb/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/deb/version.go
+++ b/internal/deb/version.go
@@ -33,7 +33,7 @@ func max(a, b int) int {
 //go:generate go run ./chrorder/main.go -package=deb -output=chrorder.go
 
 func cmpString(as, bs string) int {
-	for i := 0; i < max(len(as), len(bs)); i++ {
+	for i := range max(len(as), len(bs)) {
 		var a uint8
 		var b uint8
 		if i < len(as) {
@@ -53,7 +53,7 @@ func cmpString(as, bs string) int {
 }
 
 func trimLeadingZeroes(a string) string {
-	for i := 0; i < len(a); i++ {
+	for i := range len(a) {
 		if a[i] != '0' {
 			return a[i:]
 		}
@@ -72,7 +72,7 @@ func cmpNumeric(a, b string) int {
 	case d < 0:
 		return -1
 	}
-	for i := 0; i < len(a); i++ {
+	for i := range len(a) {
 		switch {
 		case a[i] > b[i]:
 			return 1

--- a/internal/fsutil/log.go
+++ b/internal/fsutil/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/manifestutil/log.go
+++ b/internal/manifestutil/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/pgputil/log.go
+++ b/internal/pgputil/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/scripts/log.go
+++ b/internal/scripts/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/setup/fetch_test.go
+++ b/internal/setup/fetch_test.go
@@ -18,7 +18,7 @@ func (s *S) TestFetch(c *C) {
 		CacheDir: c.MkDir(),
 	}
 
-	for fetch := 0; fetch < 3; fetch++ {
+	for fetch := range 3 {
 		release, err := setup.FetchRelease(options)
 		c.Assert(err, IsNil)
 

--- a/internal/setup/log.go
+++ b/internal/setup/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/crypto/openpgp/packet"
@@ -269,7 +270,7 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 
 	// Collect all relevant package slices.
 	successors := map[string][]string{}
-	pending := append([]SliceKey(nil), keys...)
+	pending := slices.Clone(keys)
 
 	seen := make(map[SliceKey]bool)
 	for i := range pending {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -272,7 +272,7 @@ func order(pkgs map[string]*Package, keys []SliceKey) ([]SliceKey, error) {
 	pending := append([]SliceKey(nil), keys...)
 
 	seen := make(map[SliceKey]bool)
-	for i := 0; i < len(pending); i++ {
+	for i := range pending {
 		key := pending[i]
 		if seen[key] {
 			continue
@@ -491,7 +491,7 @@ func findPrefer(path, pkg, prefer string, prefers map[preferKey]string) (found b
 	// always the case unless the release is broken. Note that
 	// the pkg reported in the error is the one inside the loop,
 	// not necessarily the input parameter.
-	for i := 0; i < len(prefers); i++ {
+	for range len(prefers) {
 		pkg = prefers[preferKey{preferTarget, path, pkg}]
 		if pkg == "" {
 			return false, nil

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -16,7 +16,7 @@ import (
 	"github.com/canonical/chisel/internal/pgputil"
 )
 
-func (p *Package) MarshalYAML() (interface{}, error) {
+func (p *Package) MarshalYAML() (any, error) {
 	return packageToYAML(p)
 }
 
@@ -68,7 +68,7 @@ type yamlPath struct {
 	Prefer   string       `yaml:"prefer,omitempty"`
 }
 
-func (yp *yamlPath) MarshalYAML() (interface{}, error) {
+func (yp *yamlPath) MarshalYAML() (any, error) {
 	type flowPath *yamlPath
 	node := &yaml.Node{}
 	err := node.Encode(flowPath(yp))
@@ -113,7 +113,7 @@ func (ya *yamlArch) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (ya yamlArch) MarshalYAML() (interface{}, error) {
+func (ya yamlArch) MarshalYAML() (any, error) {
 	if len(ya.List) == 1 {
 		return ya.List[0], nil
 	}
@@ -124,7 +124,7 @@ var _ yaml.Marshaler = yamlArch{}
 
 type yamlMode uint
 
-func (ym yamlMode) MarshalYAML() (interface{}, error) {
+func (ym yamlMode) MarshalYAML() (any, error) {
 	// Workaround for marshalling integers in octal format.
 	// Ref: https://github.com/go-yaml/yaml/issues/420.
 	node := &yaml.Node{}

--- a/internal/slicer/log.go
+++ b/internal/slicer/log.go
@@ -33,7 +33,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -44,7 +44,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1446,7 +1446,7 @@ var slicerTests = []slicerTest{{
 				break
 			}
 		}
-		opts.Selection.Slices = append(opts.Selection.Slices[:index], opts.Selection.Slices[index+1:]...)
+		opts.Selection.Slices = slices.Delete(opts.Selection.Slices, index, index+1)
 	},
 	release: map[string]string{
 		"slices/mydir/test-package.yaml": `

--- a/internal/strdist/log.go
+++ b/internal/strdist/log.go
@@ -40,7 +40,7 @@ func IsDebugOn() bool {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -51,7 +51,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/internal/testutil/containschecker.go
+++ b/internal/testutil/containschecker.go
@@ -32,7 +32,7 @@ var Contains check.Checker = &containsChecker{
 	&check.CheckerInfo{Name: "Contains", Params: []string{"container", "elem"}},
 }
 
-func commonEquals(container, elem interface{}, result *bool, error *string) bool {
+func commonEquals(container, elem any, result *bool, error *string) bool {
 	containerV := reflect.ValueOf(container)
 	elemV := reflect.ValueOf(elem)
 	switch containerV.Kind() {
@@ -71,15 +71,15 @@ func commonEquals(container, elem interface{}, result *bool, error *string) bool
 	return false
 }
 
-func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *containsChecker) Check(params []any, names []string) (result bool, error string) {
 	defer func() {
 		if v := recover(); v != nil {
 			result = false
 			error = fmt.Sprint(v)
 		}
 	}()
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return
 	}
@@ -117,9 +117,9 @@ var DeepContains check.Checker = &deepContainsChecker{
 	&check.CheckerInfo{Name: "DeepContains", Params: []string{"container", "elem"}},
 }
 
-func (c *deepContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+func (c *deepContainsChecker) Check(params []any, names []string) (result bool, error string) {
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return
 	}

--- a/internal/testutil/exec.go
+++ b/internal/testutil/exec.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -147,7 +148,7 @@ func (cmd *FakeCmd) Restore() {
 	entries := strings.Split(os.Getenv("PATH"), ":")
 	for i, entry := range entries {
 		if entry == cmd.binDir {
-			entries = append(entries[:i], entries[i+1:]...)
+			entries = slices.Delete(entries, i, i+1)
 			break
 		}
 	}

--- a/internal/testutil/filecontentchecker.go
+++ b/internal/testutil/filecontentchecker.go
@@ -48,7 +48,7 @@ var FileMatches check.Checker = &fileContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "FileMatches", Params: []string{"filename", "regex"}},
 }
 
-func (c *fileContentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *fileContentChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "Filename must be a string"
@@ -67,7 +67,7 @@ func (c *fileContentChecker) Check(params []interface{}, names []string) (result
 	return fileContentCheck(filename, params[1], c.exact)
 }
 
-func fileContentCheck(filename string, content interface{}, exact bool) (result bool, error string) {
+func fileContentCheck(filename string, content any, exact bool) (result bool, error string) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read file %q: %v", filename, err)

--- a/internal/testutil/filepresencechecker.go
+++ b/internal/testutil/filepresencechecker.go
@@ -38,7 +38,7 @@ var FileAbsent check.Checker = &filePresenceChecker{
 	present:     false,
 }
 
-func (c *filePresenceChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *filePresenceChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "filename must be a string"

--- a/internal/testutil/intcheckers.go
+++ b/internal/testutil/intcheckers.go
@@ -25,7 +25,7 @@ type intChecker struct {
 	rel string
 }
 
-func (checker *intChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (checker *intChecker) Check(params []any, names []string) (result bool, error string) {
 	a, ok := params[0].(int)
 	if !ok {
 		return false, "left-hand-side argument must be an int"

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -43,7 +43,7 @@ func (*permutationSuite) TestPermutations(c *C) {
 func (*permutationSuite) TestFuzzPermutations(c *C) {
 	for sLen := 0; sLen <= 10; sLen++ {
 		s := make([]byte, sLen)
-		for i := 0; i < sLen; i++ {
+		for i := range sLen {
 			s[i] = byte(i)
 		}
 		permutations := testutil.Permutations(s)

--- a/internal/testutil/permutation_test.go
+++ b/internal/testutil/permutation_test.go
@@ -1,7 +1,7 @@
 package testutil_test
 
 import (
-	"sort"
+	"slices"
 
 	. "gopkg.in/check.v1"
 
@@ -64,9 +64,7 @@ func (*permutationSuite) TestFuzzPermutations(c *C) {
 			}
 			duplicated[permStr] = true
 			// Check that the elements are the same.
-			sort.Slice(perm, func(i, j int) bool {
-				return perm[i] < perm[j]
-			})
+			slices.Sort(perm)
 			c.Assert(perm, DeepEquals, s, Commentf("invalid elements in permutation %v of base slice %v", perm, s))
 		}
 	}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -39,7 +39,7 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) ([]interface{}, []string) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...any) ([]any, []string) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -16,6 +16,7 @@ package testutil_test
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -44,7 +45,7 @@ func testCheck(c *check.C, checker check.Checker, result bool, error string, par
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))
 	}
-	names := append([]string{}, info.Params...)
+	names := slices.Clone(info.Params)
 	resultActual, errorActual := checker.Check(params, names)
 	if resultActual != result || errorActual != error {
 		c.Fatalf("%s.Check(%#v) returned (%#v, %#v) rather than (%#v, %#v)",

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -79,7 +79,7 @@ func TreeDump(dir string) map[string]string {
 	}
 
 	// Append identifiers to paths who share an inode e.g. hard links.
-	for i := 0; i < len(inodes); i++ {
+	for i := range inodes {
 		for _, path := range pathsByInodes[inodes[i]] {
 			result[path] = fmt.Sprintf("%s <%d>", result[path], i+1)
 		}

--- a/public/jsonwall/log.go
+++ b/public/jsonwall/log.go
@@ -35,7 +35,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -46,7 +46,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {

--- a/public/manifest/log.go
+++ b/public/manifest/log.go
@@ -35,7 +35,7 @@ func SetDebug(debug bool) {
 
 // logf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf.
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalLogger != nil {
@@ -46,7 +46,7 @@ func logf(format string, args ...interface{}) {
 // debugf sends to the logger registered via SetLogger the string resulting
 // from running format and args through Sprintf, but only if debugging was
 // enabled via SetDebug.
-func debugf(format string, args ...interface{}) {
+func debugf(format string, args ...any) {
 	globalLoggerLock.Lock()
 	defer globalLoggerLock.Unlock()
 	if globalDebug && globalLogger != nil {


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Use modern Go constructs:
* replace `interface{}` with `any` (available since [go1.18](https://tip.golang.org/doc/go1.18#language))
* replace 3-clause loop with `range` loop (available since [go1.22](https://tip.golang.org/doc/go1.22#language))
* use `slices` package (available since [go1.21](https://tip.golang.org/doc/go1.21#slices))