### PR TITLE
fix: script errors when root is /

### DIFF
--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -119,7 +119,7 @@ func (c *ContentValue) RealPath(path string, what Check) (string, error) {
 		}
 	}
 	rpath := filepath.Join(c.RootDir, path)
-	slashRoot := c.RootDir
+	slashRoot := filepath.Clean(c.RootDir)
 	if slashRoot != string(filepath.Separator) {
 		slashRoot += string(filepath.Separator)
 	}

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -118,24 +118,17 @@ func (c *ContentValue) RealPath(path string, what Check) (string, error) {
 			return "", err
 		}
 	}
-	rpath := filepath.Join(c.RootDir, path)
-	slashRoot := filepath.Clean(c.RootDir)
-	if slashRoot != string(filepath.Separator) {
-		slashRoot += string(filepath.Separator)
-	}
-	if !filepath.IsAbs(rpath) || rpath != c.RootDir && !strings.HasPrefix(rpath, slashRoot) {
+	rpath := filepath.Join(c.RootDir, cpath)
+	if !filepath.IsAbs(rpath) {
 		return "", fmt.Errorf("invalid content path: %s", path)
 	}
 	if lname, err := os.Readlink(rpath); err == nil {
-		lpath := filepath.Join(filepath.Dir(rpath), lname)
+		lpath := filepath.Join(filepath.Dir(rpath), filepath.Clean(lname))
 		lrel, err := filepath.Rel(c.RootDir, lpath)
-		if err != nil || !filepath.IsAbs(lpath) || lpath != c.RootDir && !strings.HasPrefix(lpath, slashRoot) {
+		if err != nil || !filepath.IsAbs(lpath) {
 			return "", fmt.Errorf("invalid content symlink: %s", path)
 		}
-		_, err = c.RealPath("/"+lrel, what)
-		if err != nil {
-			return "", err
-		}
+		return c.RealPath("/"+lrel, what)
 	}
 	return rpath, nil
 }

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -119,13 +119,17 @@ func (c *ContentValue) RealPath(path string, what Check) (string, error) {
 		}
 	}
 	rpath := filepath.Join(c.RootDir, path)
-	if !filepath.IsAbs(rpath) || rpath != c.RootDir && !strings.HasPrefix(rpath, c.RootDir+string(filepath.Separator)) {
+	slashRoot := c.RootDir
+	if slashRoot != string(filepath.Separator) {
+		slashRoot += string(filepath.Separator)
+	}
+	if !filepath.IsAbs(rpath) || rpath != c.RootDir && !strings.HasPrefix(rpath, slashRoot) {
 		return "", fmt.Errorf("invalid content path: %s", path)
 	}
 	if lname, err := os.Readlink(rpath); err == nil {
 		lpath := filepath.Join(filepath.Dir(rpath), lname)
 		lrel, err := filepath.Rel(c.RootDir, lpath)
-		if err != nil || !filepath.IsAbs(lpath) || lpath != c.RootDir && !strings.HasPrefix(lpath, c.RootDir+string(filepath.Separator)) {
+		if err != nil || !filepath.IsAbs(lpath) || lpath != c.RootDir && !strings.HasPrefix(lpath, slashRoot) {
 			return "", fmt.Errorf("invalid content symlink: %s", path)
 		}
 		_, err = c.RealPath("/"+lrel, what)

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -326,3 +326,9 @@ func (s *S) TestRootSingleSlash(c *C) {
 	_, err := content.RealPath("/etc/foo/bar", scripts.CheckNone)
 	c.Assert(err, IsNil)
 }
+
+func (s *S) TestNotCleanRoot(c *C) {
+	content := scripts.ContentValue{RootDir: "/foo/"}
+	_, err := content.RealPath("/foo/bar", scripts.CheckNone)
+	c.Assert(err, IsNil)
+}

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -152,7 +152,7 @@ var scriptsTests = []scriptsTest{{
 		content.read("/foo/../../file1.txt")
 	`,
 }, {
-	summary: "Symlinks do not escape the root",
+	summary: "Absolute symlinks do not escape the root",
 	content: map[string]string{
 		"foo": "whatever",
 	},

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -330,12 +330,14 @@ func (s *S) TestContentRelative(c *C) {
 
 func (s *S) TestRootSingleSlash(c *C) {
 	content := scripts.ContentValue{RootDir: "/"}
-	_, err := content.RealPath("/etc/foo/bar", scripts.CheckNone)
+	rpath, err := content.RealPath("/etc/foo/bar", scripts.CheckNone)
 	c.Assert(err, IsNil)
+	c.Assert(rpath, Equals, "/etc/foo/bar")
 }
 
 func (s *S) TestNotCleanRoot(c *C) {
-	content := scripts.ContentValue{RootDir: "/foo/"}
-	_, err := content.RealPath("/foo/bar", scripts.CheckNone)
+	content := scripts.ContentValue{RootDir: "/root/"}
+	rpath, err := content.RealPath("/foo/bar", scripts.CheckNone)
 	c.Assert(err, IsNil)
+	c.Assert(rpath, Equals, "/root/foo/bar")
 }

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -320,3 +320,9 @@ func (s *S) TestContentRelative(c *C) {
 	_, err := content.RealPath("/bar", scripts.CheckNone)
 	c.Assert(err, ErrorMatches, "internal error: content defined with relative root: foo")
 }
+
+func (s *S) TestRootSingleSlash(c *C) {
+	content := scripts.ContentValue{RootDir: "/"}
+	_, err := content.RealPath("/etc/foo/bar", scripts.CheckNone)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

Solves #221.

In the future we might want to have more extensive testing when setting the root to be "/" but the setup per test is complex as we would be polluting the system running the test itself (`chroot` with overlays might be an option). The complexity here would only make sense if justified with more of these bugs.

-----
