### PR TITLE
chore: bump versions to fix CVE

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: Check bugs and unused code
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.63.4
+          version: v1.64.8

--- a/cmd/chisel/cmd_info.go
+++ b/cmd/chisel/cmd_info.go
@@ -67,7 +67,7 @@ func (cmd *infoCmd) Execute(args []string) error {
 		for i := range notFound {
 			notFound[i] = strconv.Quote(notFound[i])
 		}
-		return fmt.Errorf("%s", "no slice definitions found for: "+strings.Join(notFound, ", "))
+		return fmt.Errorf("no slice definitions found for: %s", strings.Join(notFound, ", "))
 	}
 
 	return nil

--- a/cmd/chisel/cmd_info.go
+++ b/cmd/chisel/cmd_info.go
@@ -67,7 +67,7 @@ func (cmd *infoCmd) Execute(args []string) error {
 		for i := range notFound {
 			notFound[i] = strconv.Quote(notFound[i])
 		}
-		return fmt.Errorf("no slice definitions found for: " + strings.Join(notFound, ", "))
+		return fmt.Errorf("%s", "no slice definitions found for: "+strings.Join(notFound, ", "))
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/chisel
 
-go 1.23.12
+go 1.24.6
 
 require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/canonical/chisel
 
-go 1.23.8
+go 1.23.12
 
 require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/klauspost/compress v1.18.0
-	github.com/ulikunitz/xz v0.5.12
+	github.com/ulikunitz/xz v0.5.15
 	go.starlark.net v0.0.0-20250417143717-f57e51f710eb
 	golang.org/x/crypto v0.37.0
 	golang.org/x/term v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
-github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 go.starlark.net v0.0.0-20250417143717-f57e51f710eb h1:zOg9DxxrorEmgGUr5UPdCEwKqiqG0MlZciuCuA3XiDE=
 go.starlark.net v0.0.0-20250417143717-f57e51f710eb/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The minimal required Go version is bumped to `1.24.6` to fix [GO-2025-3956](https://pkg.go.dev/vuln/GO-2025-3956)/[CVE-2025-47906](https://www.cve.org/CVERecord?id=CVE-2025-47906). The Go version `1.23.12` cannot be used due to the unavailability in the snapstore.

The version of package `github.com/ulikunitz/xz` is bumped to `v0.5.15` to fix [GO-2025-3922](https://pkg.go.dev/vuln/GO-2025-3922)/[CVE-2025-58058](https://www.cve.org/CVERecord?id=CVE-2025-58058).

A complete `govulncheck` before the fix goes as follows:

```
=== Symbol Results ===

Vulnerability #1: GO-2025-3956
    Unexpected paths returned from LookPath in os/exec
  More info: https://pkg.go.dev/vuln/GO-2025-3956
  Standard library
    Found in: os/exec@go1.24.4
    Fixed in: os/exec@go1.24.6
    Example traces found:
      #1: internal/testutil/exec.go:35:28: testutil.init#1 calls exec.LookPath

Vulnerability #2: GO-2025-3922
    Memory leaks when decoding a corrupted multiple LZMA archives in
    github.com/ulikunitz/xz
  More info: https://pkg.go.dev/vuln/GO-2025-3922
  Module: github.com/ulikunitz/xz
    Found in: github.com/ulikunitz/xz@v0.5.12
    Fixed in: github.com/ulikunitz/xz@v0.5.15
    Example traces found:
      #1: internal/deb/extract.go:18:2: deb.init calls xz.init, which eventually calls hash.init
      #2: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls lzma.ByteReader
      #3: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls lzma.DecodeDictCap
      #4: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls lzma.Properties.String
      #5: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls lzma.Reader2.Read
      #6: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls lzma.Reader2Config.NewReader2
      #7: internal/deb/extract.go:403:33: deb.DataReader calls xz.NewReader, which eventually calls lzma.Reader2Config.Verify
      #8: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls lzma.breader.ReadByte
      #9: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls lzma.chunkHeader.String
      #10: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls lzma.chunkType.String
      #11: internal/pgputil/openpgp.go:90:19: pgputil.VerifySignature calls io.Copy, which eventually calls lzma.decoderDict.Write
      #12: internal/deb/extract.go:18:2: deb.init calls xz.init, which calls lzma.init
      #13: internal/deb/extract.go:403:33: deb.DataReader calls xz.NewReader, which eventually calls xlog.Debugf
      #14: internal/deb/extract.go:18:2: deb.init calls xz.init, which calls xlog.init
      #15: internal/deb/extract.go:403:33: deb.DataReader calls xz.NewReader
      #16: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which calls xz.Reader.Read
      #17: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls xz.blockHeader.String
      #18: internal/cache/cache.go:160:25: cache.Cache.Read calls io.ReadAll, which eventually calls xz.countingReader.Read
      #19: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls xz.footer.String
      #20: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls xz.header.String
      #21: internal/deb/extract.go:18:2: deb.init calls xz.init
      #22: internal/testutil/filecontentchecker.go:84:45: testutil.fileContentCheck calls xz.lzmaFilter.String
      #23: internal/deb/extract.go:388:33: deb.DataReader calls ar.Reader.Next, which eventually calls xz.noneHash.Write

Your code is affected by 2 vulnerabilities from 1 module and the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
```

There are no vulnerabilities found after this version bump.