### PR TITLE
feat: allow multiple ignores

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -30,10 +30,10 @@ var cutDescs = map[string]string{
 }
 
 type cmdCut struct {
-	Release string `long:"release" value-name:"<dir>"`
-	RootDir string `long:"root" value-name:"<dir>" required:"yes"`
-	Arch    string `long:"arch" value-name:"<arch>"`
-	Ignore []string `long:"ignore" choice:"unmaintained" choice:"unstable" value-name:"<cond>"`
+	Release string   `long:"release" value-name:"<dir>"`
+	RootDir string   `long:"root" value-name:"<dir>" required:"yes"`
+	Arch    string   `long:"arch" value-name:"<arch>"`
+	Ignore  []string `long:"ignore" choice:"unmaintained" choice:"unstable" value-name:"<cond>"`
 
 	Positional struct {
 		SliceRefs []string `positional-arg-name:"<slice names>" required:"yes"`

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jessevdk/go-flags"
@@ -32,7 +33,7 @@ type cmdCut struct {
 	Release string `long:"release" value-name:"<dir>"`
 	RootDir string `long:"root" value-name:"<dir>" required:"yes"`
 	Arch    string `long:"arch" value-name:"<arch>"`
-	Ignore  string `long:"ignore" choice:"unmaintained" choice:"unstable" value-name:"<cond>"`
+	Ignore []string `long:"ignore" choice:"unmaintained" choice:"unstable" value-name:"<cond>"`
 
 	Positional struct {
 		SliceRefs []string `positional-arg-name:"<slice names>" required:"yes"`
@@ -63,7 +64,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 	}
 
 	if time.Now().Before(release.Maintenance.Standard) {
-		if cmd.Ignore == "unstable" {
+		if slices.Contains(cmd.Ignore, "unstable") {
 			logf(`Warning: This release is in the "unstable" maintenance status. ` +
 				`See https://documentation.ubuntu.com/chisel/en/latest/reference/chisel-releases/chisel.yaml/#maintenance to be safe`)
 		} else {
@@ -109,7 +110,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 		}
 	}
 	if !hasMaintainedArchive {
-		if cmd.Ignore == "unmaintained" {
+		if slices.Contains(cmd.Ignore, "unmaintained") {
 			logf(`Warning: No archive has "maintained" maintenance status. ` +
 				`Consider the different Ubuntu Pro subcriptions to be safe. ` +
 				`See https://documentation.ubuntu.com/chisel/en/latest/reference/chisel-releases/chisel.yaml/#maintenance for details.`)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Allows passing multiple `--ignore` flags, for example `chisel cut --release=./ --root=rootfs --ignore=unmaintained --ignore=unstable` libc6_libs`.

Proposal for addressing [this](https://github.com/canonical/chisel-releases/pull/676) issue/PR in chisel-releases.

TLDR; in `chisel-releases` cli we want a general cut command which will try to cut both unmaintained and unstable releases (at the time of writing this is 20.04 and 25.10 respectively). As opposed to figuring out the logic dynamically we could just always pass all the ignore flags.

I would also argue that this is the intuitive behavior users would expect + allows us to trivially expand into any future conditions we might want to ignore.
