### PR TITLE
bugfix: revert change to transitive dependencies (essential)

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -358,7 +358,7 @@ func order(pkgs map[string]*Package, keys []SliceKey, arch string) ([]SliceKey, 
 	pending := slices.Clone(keys)
 
 	seen := make(map[SliceKey]bool)
-	for i := range pending {
+	for i := 0; i < len(pending); i++ {
 		key := pending[i]
 		if seen[key] {
 			continue

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1951,6 +1951,33 @@ var slicerTests = []slicerTest{{
 	manifestPaths: map[string]string{
 		"/dir/file": "file 0644 cc55e2ec {test-package_installed}",
 	},
+}, {
+	summary: "Transitive essential",
+	slices:  []setup.SliceKey{{"test-package", "first"}},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				first:
+					essential:
+						- test-package_second
+					contents:
+				second:
+					essential:
+						- test-package_third
+					contents:
+				third:
+					contents:
+						/dir/file:
+		`,
+	},
+	filesystem: map[string]string{
+		"/dir/":     "dir 0755",
+		"/dir/file": "file 0644 cc55e2ec",
+	},
+	manifestPaths: map[string]string{
+		"/dir/file": "file 0644 cc55e2ec {test-package_third}",
+	},
 }}
 
 func (s *S) TestRun(c *C) {


### PR DESCRIPTION
This commit reverts the change in
aca3b32315cda2b5e4c2e9854bf249167e328385 that changed the for loop to
use the new range semantics which was not equivalent because we were
mutating the contents of the array in the loop itself.

A test has been added to detect it.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
For context, the commit was part of PR #215 which introduced cosmetic changes to the code. The lesson here is that we should not change the code for the sake of cosmetics unless it is strictly necessary, subtle changes in semantics can introduce hard to find bugs.