### PR TITLE
fix(258): path conflicts with two single globs

### DIFF
--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -189,23 +189,23 @@ func wildcardLiteralSegmentsMatch(a, b string) bool {
 	// Check if both strings contain wildcards
 	aHasWildcard := strings.ContainsAny(a, "*?")
 	bHasWildcard := strings.ContainsAny(b, "*?")
-	
+
 	// If only one has wildcards, this is glob-to-literal matching,
 	// which is handled by the distance algorithm
 	if !aHasWildcard || !bHasWildcard {
 		return true
 	}
-	
+
 	// If either pattern contains **, skip this check as ** can match across
 	// path separators and break the structure
 	if strings.Contains(a, "**") || strings.Contains(b, "**") {
 		return true
 	}
-	
+
 	// Extract literal segments from both patterns (text between wildcards)
 	aSegments := splitAtDelimiters(a, '*', '?', '⁑')
 	bSegments := splitAtDelimiters(b, '*', '?', '⁑')
-	
+
 	// Check all literal segments from one pattern appear in the other
 	return !slices.ContainsFunc(aSegments, func(seg string) bool {
 		return seg != "" && !strings.Contains(b, seg)
@@ -239,6 +239,6 @@ func splitAtDelimiters(s string, delimiters ...rune) []string {
 	if current != "" {
 		segments = append(segments, current)
 	}
-	
+
 	return segments
 }

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -62,7 +62,7 @@ var distanceTests = []distanceTest{
 
 func (s *S) TestGlobPathIssue258(c *C) {
 	// Test for issue-258: Glob patterns with different literal segments should not match. For example:
-	// 
+	//
 	// - Pattern A: /foo/bar/libopcodes-*-system.*.so
 	//   Matches: /foo/bar/libopcodes-2.45.50-system.20251212.so
 	// - Pattern B: /foo/bar/libopcodes-*-arm64.so
@@ -80,7 +80,7 @@ func (s *S) TestGlobPathIssue258(c *C) {
 		{a: "/a/b/c-*-d.*.so", b: "/a/b/c-*-e.so", expected: false},
 		{a: "/a/b/c-*-d.*.so", b: "/a/b/c-*-d.so", expected: false},
 	}
-	
+
 	for _, test := range tests {
 		c.Logf("Testing GlobPath(%q, %q)", test.a, test.b)
 		result := strdist.GlobPath(test.a, test.b)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

https://github.com/canonical/chisel/issues/258 describes an incorrect conflict between two paths due to two single globs in the pattern. this PR fixes this issue by comparing the literal segments between the wildcards, as well as the prefix and suffix.

i've also added a bench test to measure the performance loss due to the additional check needed. excerpts from `go test ./internal/strdist/... -bench=. -count 5`:

this PR (`2997+/-93 ns/op`):

```
BenchmarkGlobPath-12              431558              2857 ns/op
BenchmarkGlobPath-12              408124              2967 ns/op
BenchmarkGlobPath-12              427386              3025 ns/op
BenchmarkGlobPath-12              450170              3111 ns/op
BenchmarkGlobPath-12              559365              3025 ns/op
```

new check skipped (`2568+/-318`):

```
BenchmarkGlobPath-12              402010              3017 ns/op
BenchmarkGlobPath-12              588462              2252 ns/op
BenchmarkGlobPath-12              734450              2402 ns/op
BenchmarkGlobPath-12              547246              2390 ns/op
BenchmarkGlobPath-12              514233              2783 ns/op
```

so about `400us` aka 17% slowdown. 

i've kept the implementation small, to keep the diff on the smaller side, but i think `GlobPath` can be organised better to improve performance and code layout -- `wildcardPrefixMatch`, `wildcardSuffixMatch` and `wildcardLiteralSegmentsMatch` could be merged together + fastpaths for the cases where the `wildcardLiteralSegmentsMatch` logic is not needed.

- fixes https://github.com/canonical/chisel/issues/258
