### PR TITLE
fix: linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,7 +62,6 @@ linters:
         - -ST1003
         - -QF1009
         - -QF1011
-        - -S1011
         - -QF1012
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,10 @@ linters:
           - staticcheck
         path: ^.*.go$
         text: '"golang.org/x/crypto/openpgp/\w+" is deprecated'
+      - linters:
+          - staticcheck
+        path: cmd/chisel/.*.go
+        text: "ST1005:"
   settings:
     staticcheck:
       checks:
@@ -57,8 +61,6 @@ linters:
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
         - -ST1012
-        - -ST1011
-        - -ST1005
         - -ST1003
         - -QF1009
         - -QF1011

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,9 +56,7 @@ linters:
         - all
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
-        - -ST1005
         - -ST1012
-        - -QF1004
         - -ST1011
         - -ST1005
         - -ST1003

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,7 +65,6 @@ linters:
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
         - -ST1012
-        - -QF1009
         - -QF1011
         - -QF1012
 issues:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,10 +28,6 @@ linters:
         text: lockFile.Unlock.*not checked
       - linters:
           - unused
-        path: cmd/chisel/main.go
-        text: addDebugCommand.*unused
-      - linters:
-          - unused
         path: ^.*/log.go$
         text: logf.*unused
       - linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,13 +66,10 @@ linters:
           - staticcheck
         path: internal/setup/setup.go
         text: "ST1012: error var preferNone"
-  settings:
-    staticcheck:
-      checks:
-        - all
-        # Checks now detecting new issues after migrating to golangci-lint v2.
-        # TODO: Remove these and solve raised issues.
-        - -QF1011
+      - linters:
+          - staticcheck
+        path: internal/testutil/containschecker.go
+        text: "QF1011"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,7 +66,6 @@ linters:
         # TODO: Remove these and solve raised issues.
         - -ST1012
         - -QF1011
-        - -QF1012
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,13 +58,20 @@ linters:
           - staticcheck
         path: ^.*/log.go$
         text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/cache/cache.go
+        text: "ST1012: error var MissErr"
+      - linters:
+          - staticcheck
+        path: internal/setup/setup.go
+        text: "ST1012: error var preferNone"
   settings:
     staticcheck:
       checks:
         - all
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
-        - -ST1012
         - -QF1011
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,6 +54,10 @@ linters:
           - staticcheck
         path: cmd/chisel/.*.go
         text: "ST1005:"
+      - linters:
+          - staticcheck
+        path: ^.*/log.go$
+        text: "ST1003:"
   settings:
     staticcheck:
       checks:
@@ -61,7 +65,6 @@ linters:
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
         - -ST1012
-        - -ST1003
         - -QF1009
         - -QF1011
         - -QF1012

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,7 +56,6 @@ linters:
         - all
         # Checks now detecting new issues after migrating to golangci-lint v2.
         # TODO: Remove these and solve raised issues.
-        - -QF1008
         - -ST1005
         - -ST1012
         - -QF1004

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,7 +63,6 @@ linters:
         - -QF1009
         - -QF1011
         - -S1011
-        - -S1005
         - -QF1012
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,7 +64,6 @@ linters:
         - -QF1011
         - -S1011
         - -S1005
-        - -QF1001
         - -QF1012
 issues:
   max-issues-per-linter: 0

--- a/cmd/chisel/cmd_help.go
+++ b/cmd/chisel/cmd_help.go
@@ -26,7 +26,7 @@ func addHelp(parser *flags.Parser) error {
 		// case, parser.Command.Active should be the command
 		// on which help is being requested (like "chisel foo
 		// --help", active is foo), or nil in the toplevel.
-		if parser.Command.Active == nil {
+		if parser.Active == nil {
 			// this means *either* a bare 'chisel --help',
 			// *or* 'chisel --help command'
 			//
@@ -101,7 +101,7 @@ func (w *manfixer) Write(buf []byte) (int, error) {
 var tpRegexp = regexp.MustCompile(`(?m)(?:^\.TP\n)+`)
 
 func (w *manfixer) flush() error {
-	str := tpRegexp.ReplaceAllLiteralString(w.Buffer.String(), ".TP\n")
+	str := tpRegexp.ReplaceAllLiteralString(w.String(), ".TP\n")
 	_, err := io.Copy(Stdout, strings.NewReader(str))
 	return err
 }
@@ -131,12 +131,12 @@ func (cmd cmdHelp) Execute(args []string) error {
 	// the subcommand is set below. The Active command at this point is `chisel
 	// help`, in the loop below we change it to be `chisel os.Args[1]
 	// os.Args[2] ...`.
-	cmd.parser.Command.Active = nil
+	cmd.parser.Active = nil
 	for _, subname := range cmd.Positional.Subs {
 		subcmd = subcmd.Find(subname)
 		if subcmd == nil {
 			sug := "chisel help"
-			if x := cmd.parser.Command.Active; x != nil && x.Name != "help" {
+			if x := cmd.parser.Active; x != nil && x.Name != "help" {
 				sug = "chisel help " + x.Name
 			}
 			return fmt.Errorf("unknown command %q, see '%s'.", subname, sug)

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -345,7 +345,7 @@ func run() error {
 				sug := "chisel help"
 				if len(xtra) > 0 {
 					sub = xtra[0]
-					if x := parser.Command.Active; x != nil && x.Name != "help" {
+					if x := parser.Active; x != nil && x.Name != "help" {
 						sug = "chisel help " + x.Name
 					}
 				}

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -206,7 +206,7 @@ func Parser() *flags.Parser {
 				name = string(opt.ShortName)
 			}
 			desc, ok := c.optDescs[name]
-			if !(c.optDescs == nil || ok) {
+			if c.optDescs != nil && !ok {
 				panicf("%s missing description for %s", c.name, name)
 			}
 			lintDesc(c.name, name, desc, opt.Description)
@@ -261,7 +261,7 @@ func Parser() *flags.Parser {
 				name = string(opt.ShortName)
 			}
 			desc, ok := c.optDescs[name]
-			if !(c.optDescs == nil || ok) {
+			if c.optDescs != nil && !ok {
 				panicf("%s missing description for %s", c.name, name)
 			}
 			lintDesc(c.name, name, desc, opt.Description)

--- a/internal/archive/testarchive/testarchive.go
+++ b/internal/archive/testarchive/testarchive.go
@@ -125,7 +125,7 @@ func (r *Release) Content() []byte {
 	digests := bytes.Buffer{}
 	for _, item := range r.Items {
 		content := item.Content()
-		digests.WriteString(fmt.Sprintf(" %s  %d  %s\n", makeSha256(content), len(content), item.Path()))
+		fmt.Fprintf(&digests," %s  %d  %s\n", makeSha256(content), len(content), item.Path())
 	}
 	content := fmt.Sprintf(string(testutil.Reindent(`
 		Origin: Ubuntu

--- a/internal/archive/testarchive/testarchive.go
+++ b/internal/archive/testarchive/testarchive.go
@@ -125,7 +125,7 @@ func (r *Release) Content() []byte {
 	digests := bytes.Buffer{}
 	for _, item := range r.Items {
 		content := item.Content()
-		fmt.Fprintf(&digests," %s  %d  %s\n", makeSha256(content), len(content), item.Path())
+		fmt.Fprintf(&digests, " %s  %d  %s\n", makeSha256(content), len(content), item.Path())
 	}
 	content := fmt.Sprintf(string(testutil.Reindent(`
 		Origin: Ubuntu

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -368,7 +368,7 @@ func extractHardLinks(pkgReader io.ReadSeeker, opts *extractHardLinkOptions) err
 	// this package.
 	if len(opts.pendingLinks) > 0 {
 		var targets []string
-		for target, _ := range opts.pendingLinks {
+		for target := range opts.pendingLinks {
 			targets = append(targets, target)
 		}
 		sort.Strings(targets)

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -2190,10 +2190,7 @@ func treeDumpManifestPaths(mfest *manifest.Manifest) (map[string]string, error) 
 		}
 
 		// append {slice1, ..., sliceN} to the end of the path dump.
-		slicesStr := make([]string, 0, len(path.Slices))
-		for _, slice := range path.Slices {
-			slicesStr = append(slicesStr, slice)
-		}
+		slicesStr := slices.Clone(path.Slices)
 		sort.Strings(slicesStr)
 		result[path.Path] = fmt.Sprintf("%s {%s}", fsDump, strings.Join(slicesStr, ","))
 		return nil

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1990,7 +1990,7 @@ func (s *S) TestRun(c *C) {
 		m := make(map[string]string)
 		for k, v := range t.release {
 			if !strings.Contains(v, "v2-archives:") {
-				v = strings.Replace(v, "archives:", "v2-archives:", -1)
+				v = strings.ReplaceAll(v, "archives:", "v2-archives:")
 			}
 			m[k] = v
 		}
@@ -2007,7 +2007,7 @@ func (s *S) TestRun(c *C) {
 			if strings.Contains(v, "format: v1") &&
 				!strings.Contains(v, "v2-archives:") &&
 				!strings.Contains(v, "default: true") {
-				v = strings.Replace(v, "format: v1", "format: v2", -1)
+				v = strings.ReplaceAll(v, "format: v1", "format: v2")
 			}
 			m[k] = v
 		}

--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -82,7 +82,7 @@ func fixupTarEntry(entry *TarEntry) {
 	if hdr.Gid == 0 && hdr.Gname == "" {
 		hdr.Gname = "root"
 	}
-	if hdr.ModTime == zeroTime {
+	if hdr.ModTime.Equal(zeroTime) {
 		hdr.ModTime = epochStartTime
 	}
 	if hdr.Format == 0 {


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Reenable linter rules and fix associated errors excluded in #274.

Following the existing approach, exclusions were added to the golangci-lint
configuration instead of `//nolint` directives in the code. This could lead to 
missing true positives as the exclusion can sometimes be unprecise.

Also remove a now useless exclusion.   