### PR TITLE
perf: improve release validation performance

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -288,8 +288,7 @@ func (r *Release) validate() error {
 	//
 	// Note: to check both prefixes we have to check `(a,b)` and `(b,a)` as the
 	// code below is not symmetric.
-	allPaths := slices.Collect(maps.Keys(paths))
-	slices.Sort(allPaths)
+	allPaths := slices.Sorted(maps.Keys(paths))
 	for oldPath, oldSlices := range paths {
 		for _, old := range oldSlices {
 			oldInfo := old.Contents[oldPath]

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -275,16 +275,16 @@ func (r *Release) validate() error {
 
 	// Check for glob and generate conflicts.
 	//
-	// This is the most time-consuming part of every command because checking
-	// each pair of paths uses an n^2 algorithm; specifically due to glob
-	// handling.
+	// A naive approach would be to check each pair of paths. That would result
+	// in an a n^2 algorithm, specifically due to glob handling; leading this
+	// to be the most time-consuming operation of almost every command.
 	//
 	// We can speed up the search by looking at the prefixes of each path that
 	// don't contain globs. Specifically two paths a and b conflict if and only
 	// if they both start with the prefix of a or with the prefix of b. We can
 	// discard directly all other parts that do not share either of the
-	// prefixes. This can be done efficiently with a radix tree or a trie or a
-	// simple list of sorted paths and using binary search (see below).
+	// prefixes. This can be done efficiently with a simple list of sorted
+	// paths and using binary search (see below).
 	//
 	// Note: to check both prefixes we have to check `(a,b)` and `(b,a)` as the
 	// code below is not symmetric.
@@ -333,6 +333,11 @@ func (r *Release) validate() error {
 						}
 						return fmt.Errorf("slices %s and %s conflict on %s and %s", old, new, oldPath, newPath)
 					} else {
+						// Once GlobPath succeeds there cannot be a conflict
+						// between oldPath and newPath, we can break here.
+						// TODO: This could actually be optimized further by
+						// reordering the loops so that once GlobPath succeeds
+						// we skip all other checks for this pair of paths.
 						break
 					}
 				}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -276,7 +276,7 @@ func (r *Release) validate() error {
 	// Check for glob and generate conflicts.
 	//
 	// A naive approach would be to check each pair of paths. That would result
-	// in an a n^2 algorithm, specifically due to glob handling; leading this
+	// in a n^2 algorithm, specifically due to glob handling; leading this
 	// to be the most time-consuming operation of almost every command.
 	//
 	// We can speed up the search by looking at the prefixes of each path that

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -297,6 +297,9 @@ func (r *Release) validate() error {
 			}
 
 			prefixLen := strings.IndexAny(oldPath, "*?")
+			if prefixLen == -1 {
+				return fmt.Errorf("internal error: invalid path: generate or glob path does not contain ' ?' or '*': %q", oldPath)
+			}
 			searchKey := oldPath[:prefixLen]
 			// startIndex is the position of the prefix or the position where
 			// the prefix would have been found.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -273,14 +274,43 @@ func (r *Release) validate() error {
 	}
 
 	// Check for glob and generate conflicts.
+	//
+	// This is the most time-consuming part of every command because checking
+	// each pair of paths uses an n^2 algorithm; specifically due to glob
+	// handling. We can speed up the process by exploiting the fact that
+	// conflicts are not allowed which means that in valid releases globs will
+	// appear at only the specific parts of the paths. There will always be a
+	// non-trivial prefix of the path that doesn't contain globs.
+	//
+	// We will speed up the search by only looking for conflicts in paths that
+	// share this same prefix. By collecting all paths and doing binary search
+	// we can find the start of the prefix. This is much simpler than other
+	// data structures like tries or radix trees which have similar algorithmic
+	// complexities.
+	allPaths := slices.Collect(maps.Keys(paths))
+	slices.Sort(allPaths)
 	for oldPath, oldSlices := range paths {
 		for _, old := range oldSlices {
 			oldInfo := old.Contents[oldPath]
 			if oldInfo.Kind != GeneratePath && oldInfo.Kind != GlobPath {
 				break
 			}
-			for newPath, newSlices := range paths {
-				if oldPath == newPath {
+
+			prefixLen := strings.IndexAny(oldPath, "*?")
+			searchKey := oldPath[:prefixLen]
+			// startIndex is the position of the prefix or the position where
+			// the prefix would have been found.
+			startIndex, _ := slices.BinarySearch(allPaths, searchKey)
+			for i := startIndex; i < len(allPaths); i++ {
+				newPath := allPaths[i]
+				if !strings.HasPrefix(newPath, searchKey) {
+					// Iterate until the prefix no longer matches, which means
+					// all other paths will fail the comparison below.
+					break
+				}
+				newSlices := paths[newPath]
+				// We know prefixes match, we can skip that part of the string.
+				if oldPath[len(searchKey)-1:] == newPath[len(searchKey)-1:] {
 					// Identical paths have been filtered earlier.
 					continue
 				}
@@ -291,13 +321,16 @@ func (r *Release) validate() error {
 							continue
 						}
 					}
-					if strdist.GlobPath(newPath, oldPath) {
+					// We know prefixes match, we can skip that part of the string.
+					if strdist.GlobPath(newPath[len(searchKey)-1:], oldPath[len(searchKey)-1:]) {
 						if (old.Package > new.Package) || (old.Package == new.Package && old.Name > new.Name) ||
 							(old.Package == new.Package && old.Name == new.Name && oldPath > newPath) {
 							old, new = new, old
 							oldPath, newPath = newPath, oldPath
 						}
 						return fmt.Errorf("slices %s and %s conflict on %s and %s", old, new, oldPath, newPath)
+					} else {
+						break
 					}
 				}
 			}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -277,16 +277,17 @@ func (r *Release) validate() error {
 	//
 	// This is the most time-consuming part of every command because checking
 	// each pair of paths uses an n^2 algorithm; specifically due to glob
-	// handling. We can speed up the process by exploiting the fact that
-	// conflicts are not allowed which means that in valid releases globs will
-	// appear at only the specific parts of the paths. There will always be a
-	// non-trivial prefix of the path that doesn't contain globs.
+	// handling.
 	//
-	// We will speed up the search by only looking for conflicts in paths that
-	// share this same prefix. By collecting all paths and doing binary search
-	// we can find the start of the prefix. This is much simpler than other
-	// data structures like tries or radix trees which have similar algorithmic
-	// complexities.
+	// We can speed up the search by looking at the prefixes of each path that
+	// don't contain globs. Specifically two paths a and b conflict if and only
+	// if they both start with the prefix of a or with the prefix of b. We can
+	// discard directly all other parts that do not share either of the
+	// prefixes. This can be done efficiently with a radix tree or a trie or a
+	// simple list of sorted paths and using binary search (see below).
+	//
+	// Note: to check both prefixes we have to check `(a,b)` and `(b,a)` as the
+	// code below is not symmetric.
 	allPaths := slices.Collect(maps.Keys(paths))
 	slices.Sort(allPaths)
 	for oldPath, oldSlices := range paths {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -298,7 +298,7 @@ func (r *Release) validate() error {
 
 			prefixLen := strings.IndexAny(oldPath, "*?")
 			if prefixLen == -1 {
-				return fmt.Errorf("internal error: invalid path: generate or glob path does not contain ' ?' or '*': %q", oldPath)
+				return fmt.Errorf("internal error: invalid path: generate or glob path does not contain '?' or '*': %q", oldPath)
 			}
 			searchKey := oldPath[:prefixLen]
 			// startIndex is the position of the prefix or the position where

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -519,6 +519,26 @@ var setupTests = []setupTest{{
 	},
 	relerror: "slices mypkg1_myslice1 and mypkg2_myslice1 conflict on /path1",
 }, {
+	summary: "When multiple prefixes match all are tested",
+	input: map[string]string{
+		"slices/mydir/mypkg1.yaml": `
+			package: mypkg1
+			slices:
+				myslice1:
+					contents:
+						/path/*/foo:
+		`,
+		"slices/mydir/mypkg2.yaml": `
+			package: mypkg2
+			slices:
+				myslice1:
+					contents:
+						/path/bar/foo1:
+						/path/bar/f*:
+		`,
+	},
+	relerror: "slices mypkg1_myslice1 and mypkg2_myslice1 conflict on /path/\\*/foo and /path/bar/f\\*",
+}, {
 	summary: "Directories must be suffixed with /",
 	input: map[string]string{
 		"slices/mydir/mypkg.yaml": `


### PR DESCRIPTION
Avoid expensive calls to look for conflicts when the prefixes do not
match.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
I tried many performance improvements and rewrites of the logic below. This are the only ones that move the needle significantly. With big rewrites of the algorithm I am able to get a ~6% more, so in my opinion it is not worth going that route of extra complexity and longer reviews; we should look for performance improvements elsewhere. I also tried many other tricks like finding the end index by using binary search as well, being more clever about the prefix, etc. and none of them increased performance more than 2/3% compared to this PR, so again they were not included as they made the code more complex.