### PR TITLE
fix: unicode is handled properly in strdist

### DIFF
--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -34,14 +34,14 @@ func Distance(a, b string, f CostFunc, cut int64) int64 {
 	}
 	lst := make([]CostInt, len(b)+1)
 	bl := 0
-	for bi, br := range b {
-		bl++
+	for _, br := range b {
 		cost := f(-1, br)
-		if cost.InsertB == Inhibit || lst[bi] == Inhibit {
-			lst[bi+1] = Inhibit
+		if cost.InsertB == Inhibit || lst[bl] == Inhibit {
+			lst[bl+1] = Inhibit
 		} else {
-			lst[bi+1] = lst[bi] + cost.InsertB
+			lst[bl+1] = lst[bl] + cost.InsertB
 		}
+		bl++
 	}
 	lst = lst[:bl+1]
 	// Not required, but caching means preventing the fast path
@@ -87,8 +87,7 @@ func Distance(a, b string, f CostFunc, cut int64) int64 {
 		if debug {
 			debugf("... %v", lst)
 		}
-		_ = stop
-		if cut != 0 && stop {
+		if cut != 0 && len(b) > 0 && stop {
 			break
 		}
 	}

--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -28,6 +28,14 @@ func StandardCost(ar, br rune) Cost {
 	return Cost{SwapAB: 1, DeleteA: 1, InsertB: 1}
 }
 
+// Distance returns the edit distance between two strings. The cost per edit is
+// given by the costFunc argument.
+//
+// There is an optional cut argument that when set will finish the computation
+// as early as possible once the final cost is certain to be >= cut. There is
+// no guarantee about the exact cost returned when this is the case other than
+// being >= cut. In particular, when cut is used, the function is not symmetric
+// on a and b.
 func Distance(a, b string, f CostFunc, cut int64) int64 {
 	if a == b {
 		return 0

--- a/internal/strdist/strdist.go
+++ b/internal/strdist/strdist.go
@@ -59,6 +59,9 @@ func Distance(a, b string, f CostFunc, cut int64) int64 {
 			lst[0] = last + cost.DeleteA
 		}
 		stop := true
+		if lst[0] < CostInt(cut) {
+			stop = false
+		}
 		i := 0
 		for _, br := range b {
 			i++
@@ -87,7 +90,7 @@ func Distance(a, b string, f CostFunc, cut int64) int64 {
 		if debug {
 			debugf("... %v", lst)
 		}
-		if cut != 0 && len(b) > 0 && stop {
+		if cut != 0 && stop {
 			break
 		}
 	}

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -58,10 +58,12 @@ var distanceTests = []distanceTest{
 	{f: strdist.GlobCost, r: 1, a: "a**f/hij", b: "abc/def/hik"},
 	{f: strdist.GlobCost, r: 2, a: "a**fg", b: "abc/def/hik"},
 	{f: strdist.GlobCost, r: 0, a: "a**f/hij/klm", b: "abc/d**m"},
+	{f: strdist.GlobCost, r: 1, a: "**a", b: ""},
 }
 
 func (s *S) TestDistance(c *C) {
 	for _, test := range distanceTests {
+		// TODO: test both permutations, at the moment the function is not symmetrical.
 		c.Logf("Test: %v", test)
 		if strings.Contains(test.a, "*") || strings.Contains(test.b, "*") {
 			c.Assert(strdist.GlobPath(test.a, test.b), Equals, test.r == 0)

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -63,7 +63,6 @@ var distanceTests = []distanceTest{
 
 func (s *S) TestDistance(c *C) {
 	for _, test := range distanceTests {
-		// TODO: test both permutations, at the moment the function is not symmetrical.
 		c.Logf("Test: %v", test)
 		if strings.Contains(test.a, "*") || strings.Contains(test.b, "*") {
 			c.Assert(strdist.GlobPath(test.a, test.b), Equals, test.r == 0)

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -60,6 +60,9 @@ var distanceTests = []distanceTest{
 	{f: strdist.GlobCost, r: 0, a: "a**f/hij/klm", b: "abc/d**m"},
 	{f: strdist.GlobCost, r: 1, a: "**a", b: ""},
 	{f: strdist.GlobCost, r: 0, a: "/*a/", b: "/a/"},
+	{f: strdist.GlobCost, r: 3, a: "abc", b: ""},
+	{f: strdist.GlobCost, r: 1, cut: 1, a: "abc", b: ""},
+	{f: strdist.GlobCost, r: 2, cut: 3, a: "ab", b: ""},
 }
 
 func (s *S) TestDistance(c *C) {

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -63,7 +63,9 @@ var distanceTests = []distanceTest{
 	{f: strdist.GlobCost, r: 0, a: "/*a/", b: "/a/"},
 	{f: strdist.GlobCost, r: 3, a: "abc", b: ""},
 	{f: strdist.GlobCost, r: 1, cut: 1, a: "abc", b: ""},
+	// Not symmetric.
 	{f: strdist.GlobCost, r: 2, cut: 3, a: "ab", b: ""},
+	{f: strdist.GlobCost, r: 2, cut: 1, a: "", b: "ab"},
 }
 
 func (s *S) TestDistance(c *C) {

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -36,6 +36,7 @@ var distanceTests = []distanceTest{
 	{f: uniqueCost, r: 6, a: "abc", b: "b"},
 	{f: uniqueCost, r: 6, a: "abc", b: "c"},
 	{f: uniqueCost, r: 9, a: "abc", b: ""},
+	{f: uniqueCost, r: 6, cut: 6, a: "abc", b: ""},
 	{f: uniqueCost, r: 5, a: "abc", b: "abcd"},
 	{f: uniqueCost, r: 5, a: "abc", b: "dabc"},
 	{f: uniqueCost, r: 10, a: "abc", b: "adbdc"},

--- a/internal/strdist/strdist_test.go
+++ b/internal/strdist/strdist_test.go
@@ -45,6 +45,11 @@ var distanceTests = []distanceTest{
 	{f: strdist.StandardCost, r: 3, a: "abcdefg", b: "axcdfgh"},
 	{f: strdist.StandardCost, r: 2, cut: 2, a: "abcdef", b: "abc"},
 	{f: strdist.StandardCost, r: 2, cut: 3, a: "abcdef", b: "abcd"},
+	{f: strdist.StandardCost, r: 3, a: "abc", b: ""},
+	{f: strdist.StandardCost, r: 1, cut: 1, a: "abc", b: ""},
+	// Not symmetric.
+	{f: strdist.StandardCost, r: 2, cut: 3, a: "ab", b: ""},
+	{f: strdist.StandardCost, r: 2, cut: 1, a: "", b: "ab"},
 	{f: strdist.GlobCost, r: 0, a: "abc*", b: "abcdef"},
 	{f: strdist.GlobCost, r: 0, a: "ab*ef", b: "abcdef"},
 	{f: strdist.GlobCost, r: 0, a: "*def", b: "abcdef"},
@@ -61,11 +66,13 @@ var distanceTests = []distanceTest{
 	{f: strdist.GlobCost, r: 0, a: "a**f/hij/klm", b: "abc/d**m"},
 	{f: strdist.GlobCost, r: 1, a: "**a", b: ""},
 	{f: strdist.GlobCost, r: 0, a: "/*a/", b: "/a/"},
-	{f: strdist.GlobCost, r: 3, a: "abc", b: ""},
-	{f: strdist.GlobCost, r: 1, cut: 1, a: "abc", b: ""},
-	// Not symmetric.
-	{f: strdist.GlobCost, r: 2, cut: 3, a: "ab", b: ""},
-	{f: strdist.GlobCost, r: 2, cut: 1, a: "", b: "ab"},
+	// Edge cases with empty strings.
+	{f: strdist.GlobCost, r: strdist.Inhibit, cut: 1, a: "/", b: ""},
+	{f: strdist.GlobCost, r: strdist.Inhibit, cut: 1, a: "", b: "/"},
+	{f: strdist.GlobCost, r: 0, cut: 1, a: "*", b: ""},
+	{f: strdist.GlobCost, r: 0, cut: 1, a: "", b: "*"},
+	{f: strdist.GlobCost, r: 0, cut: 1, a: "**", b: ""},
+	{f: strdist.GlobCost, r: 0, cut: 1, a: "", b: "**"},
 }
 
 func (s *S) TestDistance(c *C) {


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
While doing more performance work I noticed a couple of bugs in our implementation of distance. I will fix each one of them in a different PR so that the perf work can land. I have added a TODO for the next bug. I don't want to fix both as part of the same PR as it will be much harder to reason about the code, the fix for unicode in itself is pretty easy.

This PR fixes a common bug when handling strings in Go. The for loop:
```go
for bi, br := range b {
    ...
    lst[bi+1] = cost
}
```
Is iterating over a string and using `bi` which is the byte offset to store things in `lst` instead of the current rune count. In the case where the characters are ASCII it works because each rune is 1 byte but in the case of runes that take more than 1 byte this fails (see the added test case).