### PR TITLE
ci: set specific name on arch-specific scan results

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,6 +8,9 @@ jobs:
   scan:
     name: Scan for known vulnerabilities
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +48,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           sarif_file: ${{ env.TRIVY_RESULTS }}
-          token: ${{ secrets.ROCKSBOT_CHISEL_SECURITY_EVENTS }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,8 +8,9 @@ jobs:
   scan:
     name: Scan for known vulnerabilities
     runs-on: ubuntu-latest
-    # The codeql-action/upload-sarif action can only use the built-in GH token.
-    # So use it and expand its permissions instead od using a fine-grained token.
+    # The codeql-action/upload-sarif action can only use the built-in GitHub
+    # token. So use it and expand its permissions instead of using a fine-grained
+    # token.
     # See https://github.com/github/codeql-action/blob/main/upload-sarif/action.yml#L23
     permissions:
       security-events: write

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,7 +15,7 @@ jobs:
         # architecture-specific vulnerabilities.
         arch: [amd64, arm, arm64, ppc64le, s390x, riscv64]
     env:
-      TRIVY_RESULTS: 'trivy-results.sarif'
+      TRIVY_RESULTS: 'trivy-results.${{ matrix.arch }}.sarif'
       SCAN_DIR: 'release-scan'
     steps:
       - name: Download and extract latest release
@@ -45,6 +45,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           sarif_file: ${{ env.TRIVY_RESULTS }}
+          token: ${{ secrets.ROCKSBOT_CHISEL_SECURITY_EVENTS }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,6 +8,9 @@ jobs:
   scan:
     name: Scan for known vulnerabilities
     runs-on: ubuntu-latest
+    # The codeql-action/upload-sarif action can only use the built-in GH token.
+    # So use it and expand its permissions instead od using a fine-grained token.
+    # See https://github.com/github/codeql-action/blob/main/upload-sarif/action.yml#L23
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Avoid collisions between scan results for the different arch-specific artifacts.
Also set the needed permissions on the `GITHUB_TOKEN` to upload the security report. A fine-grained token cannot be used as this specific action only accept the `GITHUB_TOKEN`.