### PR TITLE
fix(ci): record and use the PR number to post the comment

### DIFF
--- a/.github/workflows/comment-perf.yaml
+++ b/.github/workflows/comment-perf.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: benchmark-report
-          path: report.md
+          path: benchmark-report.md
           github-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}
           run-id: ${{ github.event.workflow_run.id }}
 
@@ -38,7 +38,7 @@ jobs:
           # Filters and formats the JSON into a `key=value` string with basic error handling.
           JQ_FILTER: >-
             .[0]
-            | if (.number == null) then error("Could not find PR number") end
+            | if (.number == null) then error("Cannot find PR number") end
             | "number=\(.number)"
         run: |
           gh pr list --repo "${{ github.repository }}" --state all --search "${QUERY_PR}" \
@@ -47,6 +47,6 @@ jobs:
       - name: Post message to PR
         uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # v2
         with:
-          message-path: report.md
+          message-path: benchmark-report.md
           issue: ${{ steps.get-pr-number.outputs.number }}
           repo-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}

--- a/.github/workflows/comment-perf.yaml
+++ b/.github/workflows/comment-perf.yaml
@@ -20,14 +20,18 @@ jobs:
       - name: Download comment
         uses: actions/download-artifact@v4
         with:
-          name: benchmark-report
-          path: benchmark-report.txt
+          name: benchmark-result
+          path: benchmark-result
           github-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Read PR number
+        id: read-pr-number
+        run: echo "number=$(cat benchmark-result/pr_number)" >> $GITHUB_OUTPUT
+
       - name: Post message to PR
-        uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8
+        uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # v2
         with:
-          message-path: benchmark-report.txt
-          issue: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message-path: benchmark-result/report.md
+          issue: ${{ steps.read-pr-number.outputs.number }}
           repo-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}

--- a/.github/workflows/comment-perf.yaml
+++ b/.github/workflows/comment-perf.yaml
@@ -20,18 +20,22 @@ jobs:
       - name: Download comment
         uses: actions/download-artifact@v4
         with:
-          name: benchmark-result
-          path: benchmark-result
+          name: benchmark-report
+          path: report.md
           github-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read PR number
-        id: read-pr-number
-        run: echo "number=$(cat benchmark-result/pr_number)" >> $GITHUB_OUTPUT
+      - name: Get PR number
+        id: get-pr-number
+        run: |
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}&state=open" --jq '.[0].number')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}
 
       - name: Post message to PR
         uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # v2
         with:
-          message-path: benchmark-result/report.md
-          issue: ${{ steps.read-pr-number.outputs.number }}
+          message-path: report.md
+          issue: ${{ steps.get-pr-number.outputs.number }}
           repo-token: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}

--- a/.github/workflows/comment-perf.yaml
+++ b/.github/workflows/comment-perf.yaml
@@ -32,7 +32,9 @@ jobs:
           # The branch name is considered an untrusted input value (under the
           # contributor's control), so store it in a variable to avoid shell
           # injection.
-          QUERY_PR: "head:${{ github.event.workflow_run.head_branch }} ${{ github.event.workflow_run.head_sha }}"
+          # In the unlikely case where multiple PRs, on the same branch, from the
+          # same author exists, the most recent one is selected.
+          QUERY_PR: "head:${{ github.event.workflow_run.head_branch }} sort:updated-desc author:${{ github.event.workflow_run.head_repository.owner.login }} ${{ github.event.workflow_run.head_sha }}"
           # Filters and formats the JSON into a `key=value` string with basic error handling.
           JQ_FILTER: >-
             .[0]

--- a/.github/workflows/comment-perf.yaml
+++ b/.github/workflows/comment-perf.yaml
@@ -27,11 +27,20 @@ jobs:
 
       - name: Get PR number
         id: get-pr-number
-        run: |
-          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}&state=open" --jq '.[0].number')
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.ROCKSBOT_CHISEL_PR_COMMENTER }}
+          # The branch name is considered an untrusted input value (under the
+          # contributor's control), so store it in a variable to avoid shell
+          # injection.
+          QUERY_PR: "head:${{ github.event.workflow_run.head_branch }} ${{ github.event.workflow_run.head_sha }}"
+          # Filters and formats the JSON into a `key=value` string with basic error handling.
+          JQ_FILTER: >-
+            .[0]
+            | if (.number == null) then error("Could not find PR number") end
+            | "number=\(.number)"
+        run: |
+          gh pr list --repo "${{ github.repository }}" --state all --search "${QUERY_PR}" \
+          --json number --jq "${JQ_FILTER}" >> "${GITHUB_OUTPUT}"
 
       - name: Post message to PR
         uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # v2

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -68,14 +68,9 @@ jobs:
           chmod +x base head
           hyperfine --export-markdown report.md "./base info --release ./chisel-releases 'python3.12_core'" -n "BASE" "./head info --release ./chisel-releases 'python3.12_core'" -n "HEAD"
 
-      - name: Save PR number
-        run: echo "${{ github.event.pull_request.number }}" > pr_number
-
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-result
-          path: |
-            report.md
-            pr_number
+          name: benchmark-report
+          path: report.md
           retention-days: 1

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -66,11 +66,11 @@ jobs:
         id: benchmark
         run: |
           chmod +x base head
-          hyperfine --export-markdown report.md "./base info --release ./chisel-releases 'python3.12_core'" -n "BASE" "./head info --release ./chisel-releases 'python3.12_core'" -n "HEAD"
+          hyperfine --export-markdown benchmark-report.md "./base info --release ./chisel-releases 'python3.12_core'" -n "BASE" "./head info --release ./chisel-releases 'python3.12_core'" -n "HEAD"
 
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-report
-          path: report.md
+          path: benchmark-report.md
           retention-days: 1

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -65,14 +65,17 @@ jobs:
       - name: Run benchmark
         id: benchmark
         run: |
-          msg_file="$(mktemp)"
-          echo "msg_file=$msg_file" >> $GITHUB_OUTPUT
           chmod +x base head
-          hyperfine --export-markdown "$msg_file" "./base info --release ./chisel-releases 'python3.12_core'" -n "BASE" "./head info --release ./chisel-releases 'python3.12_core'" -n "HEAD"
+          hyperfine --export-markdown report.md "./base info --release ./chisel-releases 'python3.12_core'" -n "BASE" "./head info --release ./chisel-releases 'python3.12_core'" -n "HEAD"
+
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr_number
 
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-report
-          path: ${{ steps.benchmark.outputs.msg_file }}
+          name: benchmark-result
+          path: |
+            report.md
+            pr_number
           retention-days: 1


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Properly get the PR number associated to the benchmark run to post the comment
in the right place.
The approach tries to limit injection risk, applying the strategy recommended in 
https://securitylab.github.com/resources/github-actions-untrusted-input

Tested with https://github.com/upils/chisel/pull/12 after merging this change in my fork.