### PR TITLE
feat: private slices

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -55,6 +55,9 @@ func (cmd *cmdCut) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
+		if sliceKey.IsPrivate() {
+			return fmt.Errorf("cannot cut private slice %s", sliceRef)
+		}
 		sliceKeys[i] = sliceKey
 	}
 

--- a/cmd/chisel/cmd_cut_test.go
+++ b/cmd/chisel/cmd_cut_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	chisel "github.com/canonical/chisel/cmd/chisel"
+)
+
+func (s *ChiselSuite) TestCutRejectsPrivateSlice(c *C) {
+	dir := c.MkDir()
+	_, err := chisel.Parser().ParseArgs([]string{"cut", "--root", dir, "mypkg__priv"})
+	c.Assert(err, ErrorMatches, `cannot cut private slice mypkg__priv`)
+}

--- a/cmd/chisel/cmd_find.go
+++ b/cmd/chisel/cmd_find.go
@@ -87,12 +87,15 @@ func match(slice *setup.Slice, query string) bool {
 }
 
 // findSlices returns slices from the provided release that match all of the
-// query strings (AND).
+// query strings (AND). Private slices are never returned.
 func findSlices(release *setup.Release, query []string) (slices []*setup.Slice, err error) {
 	slices = []*setup.Slice{}
 	for _, pkg := range release.Packages {
 		for _, slice := range pkg.Slices {
 			if slice == nil {
+				continue
+			}
+			if (setup.SliceKey{Package: slice.Package, Slice: slice.Name}).IsPrivate() {
 				continue
 			}
 			allMatch := true

--- a/cmd/chisel/cmd_find_test.go
+++ b/cmd/chisel/cmd_find_test.go
@@ -43,7 +43,7 @@ var sampleRelease = &setup.Release{
 	},
 	Packages: map[string]*setup.Package{
 		"openjdk-8-jdk": makeSamplePackage("openjdk-8-jdk", []string{"bins", "config", "core", "libs", "utils"}),
-		"python3.10":    makeSamplePackage("python3.10", []string{"bins", "config", "core", "libs", "utils"}),
+		"python3.10":    makeSamplePackage("python3.10", []string{"bins", "config", "core", "libs", "utils", "_priv"}),
 	},
 }
 
@@ -122,6 +122,27 @@ var findTests = []findTest{{
 	summary: "Several terms, one does not match",
 	release: sampleRelease,
 	query:   []string{"python", "slice"},
+	result:  []*setup.Slice{},
+}, {
+	summary: "Private slices are hidden when matching by package",
+	release: sampleRelease,
+	query:   []string{"python3.10"},
+	result: []*setup.Slice{
+		sampleRelease.Packages["python3.10"].Slices["bins"],
+		sampleRelease.Packages["python3.10"].Slices["config"],
+		sampleRelease.Packages["python3.10"].Slices["core"],
+		sampleRelease.Packages["python3.10"].Slices["libs"],
+		sampleRelease.Packages["python3.10"].Slices["utils"],
+	},
+}, {
+	summary: "Private slices are hidden when matching by full slice name",
+	release: sampleRelease,
+	query:   []string{"python3.10__priv"},
+	result:  []*setup.Slice{},
+}, {
+	summary: "Private slices are hidden when matching by slice-only query",
+	release: sampleRelease,
+	query:   []string{"__priv"},
 	result:  []*setup.Slice{},
 }}
 

--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -217,3 +217,43 @@ func (s *ChiselSuite) TestInfoCommand(c *C) {
 		c.Assert(s.Stdout(), Equals, strings.TrimSpace(test.stdout)+"\n")
 	}
 }
+
+func (s *ChiselSuite) TestInfoPrivateSlice(c *C) {
+	s.ResetStdStreams()
+
+	input := map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+					essential:
+						mypkg__priv: {}
+				_priv:
+					contents:
+						/usr/bin/cc:
+		`,
+	}
+
+	dir := c.MkDir()
+	for path, data := range input {
+		fpath := filepath.Join(dir, path)
+		err := os.MkdirAll(filepath.Dir(fpath), 0755)
+		c.Assert(err, IsNil)
+		err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	_, err := chisel.Parser().ParseArgs([]string{"info", "--release", dir, "mypkg__priv"})
+	c.Assert(err, IsNil)
+
+	expected := `
+		package: mypkg
+		slices:
+			_priv:
+				contents:
+					/usr/bin/cc: {}
+	`
+	expected = string(testutil.Reindent(expected))
+	c.Assert(s.Stdout(), Equals, strings.TrimSpace(expected)+"\n")
+}

--- a/internal/apacheutil/util.go
+++ b/internal/apacheutil/util.go
@@ -5,6 +5,7 @@ package apacheutil
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type SliceKey struct {
@@ -14,14 +15,20 @@ type SliceKey struct {
 
 func (s SliceKey) String() string { return s.Package + "_" + s.Slice }
 
+// IsPrivate reports whether the slice name marks the slice as private.
+// Private slices begin with a single underscore and may only be used as
+// essentials of other slices; they cannot be selected directly.
+func (s SliceKey) IsPrivate() bool { return strings.HasPrefix(s.Slice, "_") }
+
 // FnameExp matches the slice definition file basename.
 var FnameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})\.yaml$`)
 
 // SnameExp matches only the slice name, without the leading package name.
-var SnameExp = regexp.MustCompile(`^([a-z](?:-?[a-z0-9]){2,})$`)
+// An optional single leading underscore marks the slice as private.
+var SnameExp = regexp.MustCompile(`^(_?[a-z](?:-?[a-z0-9]){2,})$`)
 
 // knameExp matches the slice full name in pkg_slice format.
-var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})_([a-z](?:-?[a-z0-9]){2,})$`)
+var knameExp = regexp.MustCompile(`^([a-z0-9](?:-?[.a-z0-9+]){1,})_(_?[a-z](?:-?[a-z0-9]){2,})$`)
 
 func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	match := knameExp.FindStringSubmatch(sliceKey)

--- a/internal/apacheutil/util_test.go
+++ b/internal/apacheutil/util_test.go
@@ -43,6 +43,18 @@ var sliceKeyTests = []struct {
 	input:    "a._bar",
 	expected: apacheutil.SliceKey{Package: "a.", Slice: "bar"},
 }, {
+	input:    "foo__bar",
+	expected: apacheutil.SliceKey{Package: "foo", Slice: "_bar"},
+}, {
+	input:    "foo__abc",
+	expected: apacheutil.SliceKey{Package: "foo", Slice: "_abc"},
+}, {
+	input: "foo___bar",
+	err:   `invalid slice reference: "foo___bar"`,
+}, {
+	input: "foo__ab",
+	err:   `invalid slice reference: "foo__ab"`,
+}, {
 	input: "foo_ba",
 	err:   `invalid slice reference: "foo_ba"`,
 }, {
@@ -93,4 +105,10 @@ func (s *S) TestParseSliceKey(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(key, DeepEquals, test.expected)
 	}
+}
+
+func (s *S) TestIsPrivate(c *C) {
+	c.Assert(apacheutil.SliceKey{Package: "foo", Slice: "_bar"}.IsPrivate(), Equals, true)
+	c.Assert(apacheutil.SliceKey{Package: "foo", Slice: "bar"}.IsPrivate(), Equals, false)
+	c.Assert(apacheutil.SliceKey{Package: "foo", Slice: ""}.IsPrivate(), Equals, false)
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -304,6 +304,26 @@ func (r *Release) validate() error {
 		}
 	}
 
+	// Check that every private slice is referenced as an essential by some
+	// other slice. Private slices cannot be selected directly, so an
+	// unreferenced one is dead code.
+	referenced := make(map[SliceKey]bool)
+	for _, pkg := range r.Packages {
+		for _, slice := range pkg.Slices {
+			for ref := range slice.Essential {
+				referenced[ref] = true
+			}
+		}
+	}
+	for _, pkg := range r.Packages {
+		for _, slice := range pkg.Slices {
+			key := SliceKey{Package: pkg.Name, Slice: slice.Name}
+			if key.IsPrivate() && !referenced[key] {
+				return fmt.Errorf("private slice %s is not referenced by any other slice", key)
+			}
+		}
+	}
+
 	// Check for cycles.
 	// Note: For release validation an essential with a specific arch is the
 	// same as an essential with all archs, i.e. Chisel does not use arch to
@@ -467,6 +487,12 @@ func stripBase(baseDir, path string) string {
 
 func Select(release *Release, slices []SliceKey, arch string) (*Selection, error) {
 	logf("Selecting slices...")
+
+	for _, key := range slices {
+		if key.IsPrivate() {
+			return nil, fmt.Errorf("cannot select private slice %s", key)
+		}
+	}
 
 	var err error
 	if arch == "" {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3993,6 +3993,70 @@ var setupTests = []setupTest{{
 	},
 	selslices: []setup.SliceKey{{"mypkg", "_priv"}},
 	selerror:  `cannot select private slice mypkg__priv`,
+}, {
+	summary: "Chained private slices: pub -> _priv1 -> _priv2",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				pub:
+					essential:
+						mypkg__priv1: {}
+				_priv1:
+					essential:
+						mypkg__priv2: {}
+					contents:
+						/usr/bin/one:
+				_priv2:
+					contents:
+						/usr/bin/two:
+		`,
+	},
+	selslices: []setup.SliceKey{{"mypkg", "pub"}},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "mypkg",
+			Name:    "_priv2",
+			Contents: map[string]setup.PathInfo{
+				"/usr/bin/two": {Kind: setup.CopyPath},
+			},
+		}, {
+			Package: "mypkg",
+			Name:    "_priv1",
+			Essential: map[setup.SliceKey]setup.EssentialInfo{
+				{"mypkg", "_priv2"}: {},
+			},
+			Contents: map[string]setup.PathInfo{
+				"/usr/bin/one": {Kind: setup.CopyPath},
+			},
+		}, {
+			Package: "mypkg",
+			Name:    "pub",
+			Essential: map[setup.SliceKey]setup.EssentialInfo{
+				{"mypkg", "_priv1"}: {},
+			},
+		}},
+	},
+}, {
+	summary: "Chained private slice with cycle detected",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				pub:
+					essential:
+						mypkg__priv1: {}
+				_priv1:
+					essential:
+						mypkg__priv2: {}
+				_priv2:
+					essential:
+						mypkg__priv1: {}
+		`,
+	},
+	relerror: `essential loop detected: mypkg__priv1, mypkg__priv2`,
 }}
 
 func (s *S) TestParseRelease(c *C) {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1391,7 +1391,7 @@ var setupTests = []setupTest{{
 						/usr/bin/cc:
 		`,
 	},
-	relerror: `invalid slice name "cc" in slices/mydir/mypkg.yaml \(must start with a-z, len >= 3, only a-z / 0-9 / -\)`,
+	relerror: `invalid slice name "cc" in slices/mydir/mypkg.yaml \(must start with a-z or _, len >= 3 after the optional _, only a-z / 0-9 / -\)`,
 }, {
 	summary: "Invalid slice hint - too long",
 	input: map[string]string{
@@ -3896,6 +3896,103 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `package "mypkg" slices defined more than once: slices/dir1/mypkg.yaml and slices/dir2/mypkg.yaml`,
+}, {
+	summary: "Private slice referenced as essential by a public slice (same package)",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+					essential:
+						mypkg__priv: {}
+				_priv:
+					contents:
+						/usr/bin/cc:
+		`,
+	},
+	selslices: []setup.SliceKey{{"mypkg", "myslice"}},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "mypkg",
+			Name:    "_priv",
+			Contents: map[string]setup.PathInfo{
+				"/usr/bin/cc": {Kind: setup.CopyPath},
+			},
+		}, {
+			Package: "mypkg",
+			Name:    "myslice",
+			Essential: map[setup.SliceKey]setup.EssentialInfo{
+				{"mypkg", "_priv"}: {},
+			},
+		}},
+	},
+}, {
+	summary: "Private slice referenced as essential by a public slice (cross-package)",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg1.yaml": `
+			package: mypkg1
+			slices:
+				myslice:
+					essential:
+						mypkg2__priv: {}
+		`,
+		"slices/mydir/mypkg2.yaml": `
+			package: mypkg2
+			slices:
+				_priv:
+					contents:
+						/usr/bin/cc:
+		`,
+	},
+	selslices: []setup.SliceKey{{"mypkg1", "myslice"}},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "mypkg2",
+			Name:    "_priv",
+			Contents: map[string]setup.PathInfo{
+				"/usr/bin/cc": {Kind: setup.CopyPath},
+			},
+		}, {
+			Package: "mypkg1",
+			Name:    "myslice",
+			Essential: map[setup.SliceKey]setup.EssentialInfo{
+				{"mypkg2", "_priv"}: {},
+			},
+		}},
+	},
+}, {
+	summary: "Unreferenced private slice is rejected",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+				_priv:
+					contents:
+						/usr/bin/cc:
+		`,
+	},
+	relerror: `private slice mypkg__priv is not referenced by any other slice`,
+}, {
+	summary: "Private slice cannot be selected directly",
+	input: map[string]string{
+		"chisel.yaml": strings.ReplaceAll(testutil.DefaultChiselYaml, "format: v1", "format: v3"),
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+					essential:
+						mypkg__priv: {}
+				_priv:
+					contents:
+						/usr/bin/cc:
+		`,
+	},
+	selslices: []setup.SliceKey{{"mypkg", "_priv"}},
+	selerror:  `cannot select private slice mypkg__priv`,
 }}
 
 func (s *S) TestParseRelease(c *C) {
@@ -4342,6 +4439,50 @@ func (s *S) TestSelectEmptyArch(c *C) {
 	}
 	expected := []string{"myotherslice", "myslice"}
 	c.Assert(sliceNames, DeepEquals, expected)
+}
+
+var privateSliceFormatGatingTests = []struct {
+	summary string
+	format  string
+}{{
+	summary: "v1",
+	format:  "v1",
+}, {
+	summary: "v2",
+	format:  "v2",
+}}
+
+func (s *S) TestPrivateSliceFormatGating(c *C) {
+	mypkgYAML := `
+		package: mypkg
+		slices:
+			myslice:
+				essential:
+					- mypkg__priv
+			_priv:
+				contents:
+					/usr/bin/cc:
+	`
+	for _, test := range privateSliceFormatGatingTests {
+		c.Logf("Format: %s", test.summary)
+
+		input := map[string]string{
+			"chisel.yaml":             strings.ReplaceAll(string(testutil.DefaultChiselYaml), "format: v1", "format: "+test.format),
+			"slices/mydir/mypkg.yaml": mypkgYAML,
+		}
+
+		dir := c.MkDir()
+		for path, data := range input {
+			fpath := filepath.Join(dir, path)
+			err := os.MkdirAll(filepath.Dir(fpath), 0o755)
+			c.Assert(err, IsNil)
+			err = os.WriteFile(fpath, testutil.Reindent(data), 0o644)
+			c.Assert(err, IsNil)
+		}
+
+		_, err := setup.ReadRelease(dir)
+		c.Assert(err, ErrorMatches, `private slice mypkg__priv requires format v3`)
+	}
 }
 
 // oldEssentialToV3 converts the essentials in v1 and v2, both 'essential', and

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -485,7 +485,10 @@ func parsePackage(format, pkgName, pkgPath string, data []byte) (*Package, error
 	for sliceName, yamlSlice := range yamlPkg.Slices {
 		match := apacheutil.SnameExp.FindStringSubmatch(sliceName)
 		if match == nil {
-			return nil, fmt.Errorf("invalid slice name %q in %s (must start with a-z, len >= 3, only a-z / 0-9 / -)", sliceName, pkgPath)
+			return nil, fmt.Errorf("invalid slice name %q in %s (must start with a-z or _, len >= 3 after the optional _, only a-z / 0-9 / -)", sliceName, pkgPath)
+		}
+		if strings.HasPrefix(sliceName, "_") && format != "v3" {
+			return nil, fmt.Errorf("private slice %s requires format v3", SliceKey{pkgName, sliceName})
 		}
 		hintNotPrintable := strings.ContainsFunc(yamlSlice.Hint, func(r rune) bool {
 			return !unicode.IsPrint(r)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

following some recent good use-cases in chisel-releases (`systemd`, `squid`), i thought i'll attempt a proof-of-principle implementation of private slices in chisel. this is a major feature and i'm not taking it's implementation lightly. this PR is an opinionated attempt just to have some code to discuss / bring to light all the design decisions made.

**AI DISCLOSURE**: written using Claude 4.6. i then read and edited/rewrote the generated code.

with that said:

# context

see, for example, [this](https://github.com/canonical/chisel-releases/pull/993#discussion_r3094363361) (short) discussion.

ideally we want all the slices to be functional -- if someone cuts just that slice they get something which makes certain amount of sense and it works. e.g. if the slice is a bash script, it has bash as an essential etc. sometimes though there are very big slices like [`systemd_stabdard`](https://github.com/canonical/chisel-releases/blob/165a6e045439f274754e7c2a61f8d32876d4ab92/slices/systemd.yaml#L6) where we then [extracted a bunch of components into separate slices](https://github.com/canonical/chisel-releases/blob/165a6e045439f274754e7c2a61f8d32876d4ab92/slices/systemd.yaml#L20-L37) just to keep it organised. these slices should be as functional as possible, but it sometimes does not really make sense / is not possible to make them functional by themselves and we're forced to inline them. with private slices we would be able to organise layout of such big slices better. this is a feature purely for chisel-releases maintainers and contributors. it makes organisation of files in slices much more manageable.

# this PR

introduce _private slices_ -- slices which can only be used internally as essentials, but can not be cut. any slice who's name begins with `_` is private. they are then referenced as e.g. `mypkg__priv` in essentials. this does not break any existing slices since `_` was not a valid character to start the slice name with.

here are the main design decisions / considerations i've come across:

1. exactly one optional leading `_`. the minimum length requirement (`>= 3` chars) applies *after* the optional `_`, so the shortest valid private slice name is `_abc`. `__abc` is invalid since it starts with two `_`'s.
2. `find _foo` already means _"match slice name only, any package"_. rather than breaking that ux, private slices are never returned by `find` -- even when other queries would otherwise match them. i'm unsure how bad it would be to change the ux for the find command, so i've leant on the side of non-breaking changes.
3. `chisel info` on private slices is allowed because it didn't break anything. trivial to disallow.
4. private slices are recorded normally in manifest.wall since it's used for SBOM generation and that information is needed there.
5. cross-package references are allowed. a public slice in `foo` may list `bar__priv` as essential. this is the more permissive version of private slices. one where private slices are private to the package would *also* be useful. i just decided to go with this one for the sake of the initial proposal.
6. private slices are available in `v3` only: `_`-prefixed names continue to be rejected in `v1` and `v2`. since `_`-prefixed names were previously rejected by the slice-name regex in *all* formats, no existing release can rely on them, so gating to v3 is not a breaking change for v3 either. i can see an argument for it being a `v4` thing though, although again, i don't think this would be a breaking change, so it does not, in principle, warrant a `v4`
7. if a release contains unreferenced private slices, it is rejected. this is an opinionated decision and i chose to be strict here.
8. `cmd cut` rejects private slice arguments at the CLI layer since it can detect them fast and fail fast. `setup.Select` also rejects private keys as a stronger guarantee.
9. **forward-compatibility caveat**: an older chisel binary reading a new release
that uses private slices will fail at slice-name parsing. the failure is
loud and immediate — not silent. this is the same risk profile as any
additive grammar change. an alternative approach would be to e.g. add `private:` field to slices and not rely on `_`(?) lots of simmilar considerations mentioned above would still apply though.

_edit:_

10. it could be useful to sometimes be able to slice private slices, even if just for the sake of some skeleton tests / to copy cut the private slice into a temp rootfs and then copy some files out of it. maybe `chisel cut package__private --ignore=private` as an api for that ...? 🤔 for now i left that as out of scope. let's see where the discussion goes.