### PR TITLE
chore: rename errors to comply with ST1012

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,10 +56,6 @@ linters:
         text: "ST1003:"
       - linters:
           - staticcheck
-        path: internal/cache/cache.go
-        text: "ST1012: error var MissErr"
-      - linters:
-          - staticcheck
         path: internal/testutil/containschecker.go
         text: "QF1011"
 issues:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,10 +60,6 @@ linters:
         text: "ST1012: error var MissErr"
       - linters:
           - staticcheck
-        path: internal/setup/setup.go
-        text: "ST1012: error var preferNone"
-      - linters:
-          - staticcheck
         path: internal/testutil/containschecker.go
         text: "QF1011"
 issues:

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -377,7 +377,7 @@ func (index *ubuntuIndex) fetch(path, digest string, flags fetchFlags) (io.ReadS
 	reader, err := index.archive.cache.Open(digest)
 	if err == nil {
 		return reader, nil
-	} else if err != cache.MissErr {
+	} else if err != cache.ErrMiss {
 		return nil, err
 	}
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -91,7 +91,7 @@ func (cw *Writer) Digest() string {
 
 const digestKind = "sha256"
 
-var MissErr = fmt.Errorf("not cached")
+var ErrMiss = fmt.Errorf("not cached")
 
 func (c *Cache) filePath(digest string) string {
 	return filepath.Join(c.Dir, digestKind, digest)
@@ -134,12 +134,12 @@ func (c *Cache) Write(digest string, data []byte) error {
 
 func (c *Cache) Open(digest string) (io.ReadSeekCloser, error) {
 	if c.Dir == "" || digest == "" {
-		return nil, MissErr
+		return nil, ErrMiss
 	}
 	filePath := c.filePath(digest)
 	file, err := os.Open(filePath)
 	if os.IsNotExist(err) {
-		return nil, MissErr
+		return nil, ErrMiss
 	} else if err != nil {
 		return nil, fmt.Errorf("cannot open cache file: %v", err)
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -46,11 +46,11 @@ func (s *S) TestCacheEmpty(c *C) {
 	cc := cache.Cache{c.MkDir()}
 
 	_, err := cc.Open(data1Digest)
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 	_, err = cc.Read(data1Digest)
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 	_, err = cc.Read("")
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 }
 
 func (s *S) TestCacheReadWrite(c *C) {
@@ -73,9 +73,9 @@ func (s *S) TestCacheReadWrite(c *C) {
 	c.Assert(string(data2), Equals, "data2")
 
 	_, err = cc.Read(data3Digest)
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 	_, err = cc.Read("")
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 
 	_, err = os.Stat(data1Path)
 	c.Assert(err, IsNil)
@@ -131,9 +131,9 @@ func (s *S) TestCacheWrongDigest(c *C) {
 	c.Assert(errClose, ErrorMatches, "expected digest "+data1Digest+", got "+data2Digest)
 
 	_, err = cc.Read(data1Digest)
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 	_, err = cc.Read(data2Digest)
-	c.Assert(err, Equals, cache.MissErr)
+	c.Assert(err, Equals, cache.ErrMiss)
 }
 
 func (s *S) TestCacheOpen(c *C) {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -231,7 +231,7 @@ func (r *Release) validate() error {
 							_, err := preferredPathPackage(newPath, new.Package, old.Package, prefers)
 							if err == nil {
 								continue
-							} else if err != preferNone {
+							} else if err != errPreferNone {
 								return err
 							}
 						}
@@ -585,10 +585,10 @@ func preferredPathPackage(path, pkg1, pkg2 string, prefers map[preferKey]string)
 		pkg1, pkg2 = sortPair(conflict, sample)
 		return "", fmt.Errorf("package %q and %q conflict on %s without prefer relationship", pkg1, pkg2, path)
 	}
-	return "", preferNone
+	return "", errPreferNone
 }
 
-var preferNone = errors.New("no prefer relationship")
+var errPreferNone = errors.New("no prefer relationship")
 
 func findPrefer(path, pkg, prefer string, prefers map[preferKey]string) (found bool, err error) {
 	if len(prefers) == 0 {


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Rename two errors and remove the associated linter exclusions to comply with ST1012.