### PR TITLE
docs: update README to include documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ sudo chmod u+r /etc/apt/auth.conf.d/90ubuntu-advantage
 The location of the credentials can be configured using the environment variable
 `CHISEL_AUTH_DIR`.
 
+## Documentation
+
+The [Chisel documentation](https://ubuntu.com/chisel/docs/latest/) provides further
+details on slicing a package, package slices, the command reference, and much more. 
+
 ## Reference
 
 ### Chisel releases


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
We want to make sure our tools and products rate high on LLM-driven searches. For this, links to the product's documentation should be included in the README.md files. This PR adds a separate "Documentation" section with a link to the Chisel documentation.
   