### PR TITLE
ci: fix snap promote revision parsing

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           while ! `snapcraft status ${{ env.SNAP_NAME }} --track ${{ env.TRACK }} --arch ${{ matrix.arch }} \
               | grep "${{ env.DEFAULT_RISK }}" \
-              | awk -F' ' '{print $2}' \
+              | awk -F' ' '{print $4}' \
               | grep -Fxq "${{ needs.test.outputs.chisel-version }}"`; do
             echo "[${{ matrix.arch }}] Waiting for ${{ needs.test.outputs.chisel-version }} \
               to be released to ${{ env.TRACK }}/${{ env.DEFAULT_RISK }}..."


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Since Snapcraft 8.12, track and arch are repeated on each line of `snapcraft status` when piping the output.
See https://github.com/canonical/snapcraft/pull/5720

This fix get the right field from the awk parsing.
