### PR TITLE
feat: support channel in CLI cut command

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -22,12 +22,13 @@ By default it fetches the slices for the same Ubuntu version as the
 current host, unless the --release flag is used.
 
 Slices are named <package>_<slice>. For packages coming from a store, a
-channel may be appended to select which one to fetch, as in
-mybin_myslice@2.0/edge. A channel with no risk, such as @2.0, uses the
-stable risk.
+channel can be appended to select which one to fetch, as in
+mybin_myslice@2.0/edge. A channel is a <track>/<risk> value.
 
-Slices of the same package must all agree on the channel. When it is
-omitted, the default track of the package is used.
+The risk defaults to stable, so @2.0 and @2.0/stable are equivalent. When
+no channel is given at all, the default track of the package is used,
+again with the stable risk. Slices of the same package must all agree on
+the channel.
 `
 
 var cutDescs = map[string]string{

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -49,13 +49,13 @@ func (cmd *cmdCut) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	sliceKeys := make([]setup.SliceKey, len(cmd.Positional.SliceRefs))
+	sliceRefs := make([]setup.SliceRef, len(cmd.Positional.SliceRefs))
 	for i, sliceRef := range cmd.Positional.SliceRefs {
-		sliceKey, err := setup.ParseSliceKey(sliceRef)
+		ref, err := setup.ParseSliceRef(sliceRef)
 		if err != nil {
 			return err
 		}
-		sliceKeys[i] = sliceKey
+		sliceRefs[i] = ref
 	}
 
 	release, err := obtainRelease(cmd.Release)
@@ -73,7 +73,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 		}
 	}
 
-	selection, err := setup.Select(release, sliceKeys, cmd.Arch)
+	selection, err := setup.Select(release, sliceRefs, cmd.Arch)
 	if err != nil {
 		return err
 	}

--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -20,6 +20,14 @@ to create a new filesystem tree in the root location.
 
 By default it fetches the slices for the same Ubuntu version as the
 current host, unless the --release flag is used.
+
+Slices are named <package>_<slice>. For packages coming from a store, a
+channel may be appended to select which one to fetch, as in
+mybin_myslice@2.0/edge. A channel with no risk, such as @2.0, uses the
+stable risk.
+
+Slices of the same package must all agree on the channel. When it is
+omitted, the default track of the package is used.
 `
 
 var cutDescs = map[string]string{

--- a/cmd/chisel/cmd_find.go
+++ b/cmd/chisel/cmd_find.go
@@ -89,6 +89,11 @@ func match(slice *setup.Slice, query string) bool {
 // findSlices returns slices from the provided release that match all of the
 // query strings (AND).
 func findSlices(release *setup.Release, query []string) (slices []*setup.Slice, err error) {
+	for _, term := range query {
+		if strings.Contains(term, "@") {
+			return nil, fmt.Errorf("track suffix is unsupported for find: %q", term)
+		}
+	}
 	slices = []*setup.Slice{}
 	for _, pkg := range release.Packages {
 		for _, slice := range pkg.Slices {

--- a/cmd/chisel/cmd_find.go
+++ b/cmd/chisel/cmd_find.go
@@ -91,7 +91,7 @@ func match(slice *setup.Slice, query string) bool {
 func findSlices(release *setup.Release, query []string) (slices []*setup.Slice, err error) {
 	for _, term := range query {
 		if strings.Contains(term, "@") {
-			return nil, fmt.Errorf("channel is unsupported for find: %q", term)
+			return nil, fmt.Errorf("invalid slice reference %q: slices are not specific to a channel", term)
 		}
 	}
 	slices = []*setup.Slice{}

--- a/cmd/chisel/cmd_find.go
+++ b/cmd/chisel/cmd_find.go
@@ -91,7 +91,7 @@ func match(slice *setup.Slice, query string) bool {
 func findSlices(release *setup.Release, query []string) (slices []*setup.Slice, err error) {
 	for _, term := range query {
 		if strings.Contains(term, "@") {
-			return nil, fmt.Errorf("track suffix is unsupported for find: %q", term)
+			return nil, fmt.Errorf("channel is unsupported for find: %q", term)
 		}
 	}
 	slices = []*setup.Slice{}

--- a/cmd/chisel/cmd_find_test.go
+++ b/cmd/chisel/cmd_find_test.go
@@ -125,10 +125,10 @@ var findTests = []findTest{{
 	query:   []string{"python", "slice"},
 	result:  []*setup.Slice{},
 }, {
-	summary: "Track suffix is unsupported for find",
+	summary: "Channel is unsupported for find",
 	release: sampleRelease,
 	query:   []string{"python3.10_bins@3.0"},
-	err:     `track suffix is unsupported for find: "python3.10_bins@3.0"`,
+	err:     `channel is unsupported for find: "python3.10_bins@3.0"`,
 }}
 
 func (s *ChiselSuite) TestFindSlices(c *C) {

--- a/cmd/chisel/cmd_find_test.go
+++ b/cmd/chisel/cmd_find_test.go
@@ -125,10 +125,10 @@ var findTests = []findTest{{
 	query:   []string{"python", "slice"},
 	result:  []*setup.Slice{},
 }, {
-	summary: "Channel is unsupported for find",
+	summary: "Slices are not specific to a channel",
 	release: sampleRelease,
 	query:   []string{"python3.10_bins@3.0"},
-	err:     `channel is unsupported for find: "python3.10_bins@3.0"`,
+	err:     `invalid slice reference "python3.10_bins@3.0": slices are not specific to a channel`,
 }}
 
 func (s *ChiselSuite) TestFindSlices(c *C) {

--- a/cmd/chisel/cmd_find_test.go
+++ b/cmd/chisel/cmd_find_test.go
@@ -14,6 +14,7 @@ type findTest struct {
 	release *setup.Release
 	query   []string
 	result  []*setup.Slice
+	err     string
 }
 
 func makeSamplePackage(pkg string, slices []string) *setup.Package {
@@ -123,6 +124,11 @@ var findTests = []findTest{{
 	release: sampleRelease,
 	query:   []string{"python", "slice"},
 	result:  []*setup.Slice{},
+}, {
+	summary: "Track suffix is unsupported for find",
+	release: sampleRelease,
+	query:   []string{"python3.10_bins@3.0"},
+	err:     `track suffix is unsupported for find: "python3.10_bins@3.0"`,
 }}
 
 func (s *ChiselSuite) TestFindSlices(c *C) {
@@ -131,6 +137,10 @@ func (s *ChiselSuite) TestFindSlices(c *C) {
 
 		for _, query := range testutil.Permutations(test.query) {
 			slices, err := chisel.FindSlices(test.release, query)
+			if test.err != "" {
+				c.Assert(err, ErrorMatches, test.err)
+				continue
+			}
 			c.Assert(err, IsNil)
 			c.Assert(slices, DeepEquals, test.result)
 		}

--- a/cmd/chisel/cmd_info.go
+++ b/cmd/chisel/cmd_info.go
@@ -50,6 +50,12 @@ func (cmd *infoCmd) Execute(args []string) error {
 		return err
 	}
 
+	for _, query := range cmd.Positional.Queries {
+		if strings.Contains(query, "@") {
+			return fmt.Errorf("track suffix is unsupported for info: %q", query)
+		}
+	}
+
 	packages, notFound := selectPackageSlices(release, cmd.Positional.Queries)
 
 	for i, pkg := range packages {

--- a/cmd/chisel/cmd_info.go
+++ b/cmd/chisel/cmd_info.go
@@ -52,7 +52,7 @@ func (cmd *infoCmd) Execute(args []string) error {
 
 	for _, query := range cmd.Positional.Queries {
 		if strings.Contains(query, "@") {
-			return fmt.Errorf("channel is unsupported for info: %q", query)
+			return fmt.Errorf("invalid slice reference %q: slices are not specific to a channel", query)
 		}
 	}
 

--- a/cmd/chisel/cmd_info.go
+++ b/cmd/chisel/cmd_info.go
@@ -52,7 +52,7 @@ func (cmd *infoCmd) Execute(args []string) error {
 
 	for _, query := range cmd.Positional.Queries {
 		if strings.Contains(query, "@") {
-			return fmt.Errorf("track suffix is unsupported for info: %q", query)
+			return fmt.Errorf("channel is unsupported for info: %q", query)
 		}
 	}
 

--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -141,10 +141,10 @@ var infoTests = []infoTest{{
 	query:   []string{"foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"},
 	err:     `no slice definitions found for: "foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"`,
 }, {
-	summary: "Channel is unsupported for info",
+	summary: "Slices are not specific to a channel",
 	input:   infoRelease,
 	query:   []string{"mypkg1_myslice1@3.0"},
-	err:     `channel is unsupported for info: "mypkg1_myslice1@3.0"`,
+	err:     `invalid slice reference "mypkg1_myslice1@3.0": slices are not specific to a channel`,
 }}
 
 var infoRelease = map[string]string{

--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -140,6 +140,11 @@ var infoTests = []infoTest{{
 	input:   infoRelease,
 	query:   []string{"foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"},
 	err:     `no slice definitions found for: "foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"`,
+}, {
+	summary: "Track suffix is unsupported for info",
+	input:   infoRelease,
+	query:   []string{"mypkg1_myslice1@3.0"},
+	err:     `track suffix is unsupported for info: "mypkg1_myslice1@3.0"`,
 }}
 
 var infoRelease = map[string]string{

--- a/cmd/chisel/cmd_info_test.go
+++ b/cmd/chisel/cmd_info_test.go
@@ -141,10 +141,10 @@ var infoTests = []infoTest{{
 	query:   []string{"foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"},
 	err:     `no slice definitions found for: "foo_bar_foo", "a_b", "7_c", "a_b c", "a_b x_y"`,
 }, {
-	summary: "Track suffix is unsupported for info",
+	summary: "Channel is unsupported for info",
 	input:   infoRelease,
 	query:   []string{"mypkg1_myslice1@3.0"},
-	err:     `track suffix is unsupported for info: "mypkg1_myslice1@3.0"`,
+	err:     `channel is unsupported for info: "mypkg1_myslice1@3.0"`,
 }}
 
 var infoRelease = map[string]string{

--- a/internal/setup/channel.go
+++ b/internal/setup/channel.go
@@ -1,0 +1,57 @@
+package setup
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// Channel is a store channel, as in "<track>/<risk>[/<branch>]".
+type Channel struct {
+	Track  string
+	Risk   string
+	Branch string
+}
+
+func (c Channel) String() string {
+	if c.Track == "" {
+		return ""
+	}
+	channel := c.Track
+	if c.Risk != "" {
+		channel += "/" + c.Risk
+	}
+	if c.Branch != "" {
+		channel += "/" + c.Branch
+	}
+	return channel
+}
+
+// parseChannel parses a "<track>[/<risk>[/<branch>]]" channel, as written.
+// Validation is intentionally loose, the track, the risk and the branch are
+// only checked for their presence so that their values are not rejected here.
+func parseChannel(channel string) (Channel, error) {
+	if channel == "" {
+		return Channel{}, errors.New("missing channel")
+	}
+	if strings.ContainsFunc(channel, unicode.IsSpace) {
+		return Channel{}, errors.New("channel must not contain spaces")
+	}
+	segments := strings.Split(channel, "/")
+	if len(segments) > 3 {
+		return Channel{}, errors.New("channel must be <track>[/<risk>[/<branch>]]")
+	}
+	for _, segment := range segments {
+		if segment == "" {
+			return Channel{}, errors.New("channel must be <track>[/<risk>[/<branch>]]")
+		}
+	}
+	parsed := Channel{Track: segments[0]}
+	if len(segments) > 1 {
+		parsed.Risk = segments[1]
+	}
+	if len(segments) > 2 {
+		parsed.Branch = segments[2]
+	}
+	return parsed, nil
+}

--- a/internal/setup/channel.go
+++ b/internal/setup/channel.go
@@ -14,13 +14,10 @@ type Channel struct {
 }
 
 func (c Channel) String() string {
-	if c.Track == "" {
+	if c == (Channel{}) {
 		return ""
 	}
-	channel := c.Track
-	if c.Risk != "" {
-		channel += "/" + c.Risk
-	}
+	channel := c.Track + "/" + c.Risk
 	if c.Branch != "" {
 		channel += "/" + c.Branch
 	}

--- a/internal/setup/channel_test.go
+++ b/internal/setup/channel_test.go
@@ -1,0 +1,53 @@
+package setup_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/chisel/internal/setup"
+)
+
+var channelStringTests = []struct {
+	summary  string
+	channel  setup.Channel
+	expected string
+}{{
+	summary:  "An unset channel renders as empty",
+	channel:  setup.Channel{},
+	expected: "",
+}, {
+	summary:  "A track and a risk",
+	channel:  setup.Channel{Track: "3.0", Risk: "stable"},
+	expected: "3.0/stable",
+}, {
+	summary:  "A branch is appended",
+	channel:  setup.Channel{Track: "3.0", Risk: "edge", Branch: "mybranch"},
+	expected: "3.0/edge/mybranch",
+}, {
+	// A channel is never built without a risk, but rendering the risk as
+	// optional would turn the branch into one, that is a different channel.
+	summary:  "A missing risk is not skipped over",
+	channel:  setup.Channel{Track: "3.0", Branch: "mybranch"},
+	expected: "3.0//mybranch",
+}, {
+	summary:  "A missing track is visible",
+	channel:  setup.Channel{Risk: "edge"},
+	expected: "/edge",
+}}
+
+func (s *S) TestChannelString(c *C) {
+	for _, test := range channelStringTests {
+		c.Logf("Summary: %s", test.summary)
+		c.Assert(test.channel.String(), Equals, test.expected)
+	}
+}
+
+// TestChannelStringRoundTrip ensures a parsed channel renders back to the
+// value it was parsed from, once the implicit risk is set as ParseSliceRef
+// does.
+func (s *S) TestChannelStringRoundTrip(c *C) {
+	for _, channel := range []string{"3.0/stable", "3.0/edge", "3.0/stable/mybranch"} {
+		ref, err := setup.ParseSliceRef("mypkg_myslice@" + channel)
+		c.Assert(err, IsNil)
+		c.Assert(ref.Channel.String(), Equals, channel)
+	}
+}

--- a/internal/setup/channel_test.go
+++ b/internal/setup/channel_test.go
@@ -40,14 +40,3 @@ func (s *S) TestChannelString(c *C) {
 		c.Assert(test.channel.String(), Equals, test.expected)
 	}
 }
-
-// TestChannelStringRoundTrip ensures a parsed channel renders back to the
-// value it was parsed from, once the implicit risk is set as ParseSliceRef
-// does.
-func (s *S) TestChannelStringRoundTrip(c *C) {
-	for _, channel := range []string{"3.0/stable", "3.0/edge", "3.0/stable/mybranch"} {
-		ref, err := setup.ParseSliceRef("mypkg_myslice@" + channel)
-		c.Assert(err, IsNil)
-		c.Assert(ref.Channel.String(), Equals, channel)
-	}
-}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unicode"
 
 	"golang.org/x/crypto/openpgp/packet"
 
@@ -146,21 +145,19 @@ func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	return apacheutil.ParseSliceKey(sliceKey)
 }
 
-// DefaultRisk is used when a channel does not specify a risk.
+// DefaultRisk is used when a slice reference does not specify a risk.
 const DefaultRisk = "stable"
 
 // SliceRef is a slice reference with an optional channel for store packages.
-// The channel always holds a risk, that is at least "<track>/<risk>".
+// The channel always holds a risk, the default one is used when the reference
+// does not specify it.
 type SliceRef struct {
 	SliceKey SliceKey
-	Channel  string
+	Channel  Channel
 }
 
-// ParseSliceRef parses a "pkg_slice[@channel]" reference. The channel is
-// either a track, in which case the default risk is used, or a
-// "<track>/<risk>" value. Validation is intentionally loose so that longer
-// channel forms, such as "<track>/<risk>/<branch>", are accepted without
-// changes here.
+// ParseSliceRef parses a "pkg_slice[@channel]" reference. See parseChannel
+// for the accepted channel forms.
 func ParseSliceRef(ref string) (SliceRef, error) {
 	keyPart, channel, ok := strings.Cut(ref, "@")
 	if !ok {
@@ -174,32 +171,14 @@ func ParseSliceRef(ref string) (SliceRef, error) {
 	if err != nil {
 		return SliceRef{}, err
 	}
-	channel, err = validateChannel(channel)
+	parsed, err := parseChannel(channel)
 	if err != nil {
 		return SliceRef{}, fmt.Errorf("invalid slice reference %q: %s", ref, err)
 	}
-	return SliceRef{SliceKey: sliceKey, Channel: channel}, nil
-}
-
-// validateChannel returns the channel with the default risk appended if it
-// holds a track alone. Validation is intentionally loose, any number of
-// segments is accepted so that longer forms are not rejected here.
-func validateChannel(channel string) (string, error) {
-	if channel == "" {
-		return "", fmt.Errorf("missing channel")
+	if parsed.Risk == "" {
+		parsed.Risk = DefaultRisk
 	}
-	if strings.ContainsFunc(channel, unicode.IsSpace) {
-		return "", fmt.Errorf("channel must not contain spaces")
-	}
-	segments := strings.Split(channel, "/")
-	if slices.Contains(segments, "") {
-		return "", fmt.Errorf("channel must be <track> or <track>/<risk>")
-	}
-	if len(segments) == 1 {
-		// A track alone, the risk is implicit.
-		return channel + "/" + DefaultRisk, nil
-	}
-	return channel, nil
+	return SliceRef{SliceKey: sliceKey, Channel: parsed}, nil
 }
 
 func (s *Slice) String() string { return s.Package + "_" + s.Name }
@@ -212,7 +191,7 @@ type Selection struct {
 	Release *Release
 	Slices  []*Slice
 	// Channels holds the resolved channel per store package name.
-	Channels map[string]string
+	Channels map[string]Channel
 }
 
 // Prefers uses the prefer relationships and returns a map from each path to
@@ -565,23 +544,12 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 		return nil, err
 	}
 
-	// Resolve the channel per store package from the references.
+	// Resolve the channel of every store package, whether it is selected or
+	// not, and before ordering, because ordering depends on the channel of the
+	// packages it traverses.
 	channels, err := resolveChannels(release, refs)
 	if err != nil {
 		return nil, err
-	}
-	// Derive the channel from 'default-track' for the store packages without an
-	// explicit one. Note the release only defines a track, the risk is
-	// implicit. This is done for every known package, before ordering, because
-	// ordering itself depends on the channel of the packages it traverses.
-	for _, pkg := range release.Packages {
-		if pkg.Store == "" {
-			continue
-		}
-		if _, ok := channels[pkg.Name]; ok {
-			continue
-		}
-		channels[pkg.Name] = pkg.DefaultTrack + "/" + DefaultRisk
 	}
 
 	selection := &Selection{
@@ -602,7 +570,7 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 	}
 
 	// Only report the channels of the selected packages.
-	selection.Channels = make(map[string]string)
+	selection.Channels = make(map[string]Channel)
 	for _, slice := range selection.Slices {
 		if channel, ok := channels[slice.Package]; ok {
 			selection.Channels[slice.Package] = channel
@@ -640,11 +608,15 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 	return selection, nil
 }
 
-// resolveChannels collects the explicit channel per store package from the
-// references. It errors if a channel is set on a non-store package or if two
-// references to the same package specify different channels.
-func resolveChannels(release *Release, refs []SliceRef) (map[string]string, error) {
-	channels := make(map[string]string)
+// resolveChannels returns the channel of every store package of the release,
+// taken from the references and falling back to the package 'default-track'
+// with the default risk. Note the release only defines a track, the risk is
+// implicit.
+//
+// It errors if a channel is set on a non-store package or if two references to
+// the same package specify different channels.
+func resolveChannels(release *Release, refs []SliceRef) (map[string]Channel, error) {
+	channels := make(map[string]Channel)
 	for _, ref := range refs {
 		pkg, ok := release.Packages[ref.SliceKey.Package]
 		if !ok {
@@ -652,13 +624,13 @@ func resolveChannels(release *Release, refs []SliceRef) (map[string]string, erro
 			continue
 		}
 		if pkg.Store == "" {
-			if ref.Channel != "" {
+			if ref.Channel != (Channel{}) {
 				return nil, fmt.Errorf("slice %s has channel but package %q is not in a store",
 					ref.SliceKey, pkg.Name)
 			}
 			continue
 		}
-		if ref.Channel == "" {
+		if ref.Channel == (Channel{}) {
 			continue
 		}
 		if existing, ok := channels[pkg.Name]; ok && existing != ref.Channel {
@@ -666,6 +638,16 @@ func resolveChannels(release *Release, refs []SliceRef) (map[string]string, erro
 				pkg.Name, existing, ref.Channel)
 		}
 		channels[pkg.Name] = ref.Channel
+	}
+	for _, pkg := range release.Packages {
+		if pkg.Store == "" {
+			continue
+		}
+		if _, ok := channels[pkg.Name]; ok {
+			// The references take precedence over the 'default-track'.
+			continue
+		}
+		channels[pkg.Name] = Channel{Track: pkg.DefaultTrack, Risk: DefaultRisk}
 	}
 	return channels, nil
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -585,7 +585,7 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 	}
 
 	selection := &Selection{
-		Release:  release,
+		Release: release,
 	}
 
 	slices := make([]SliceKey, len(refs))

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -570,10 +570,22 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 	if err != nil {
 		return nil, err
 	}
+	// Derive the channel from 'default-track' for the store packages without an
+	// explicit one. Note the release only defines a track, the risk is
+	// implicit. This is done for every known package, before ordering, because
+	// ordering itself depends on the channel of the packages it traverses.
+	for _, pkg := range release.Packages {
+		if pkg.Store == "" {
+			continue
+		}
+		if _, ok := channels[pkg.Name]; ok {
+			continue
+		}
+		channels[pkg.Name] = pkg.DefaultTrack + "/" + DefaultRisk
+	}
 
 	selection := &Selection{
 		Release:  release,
-		Channels: channels,
 	}
 
 	slices := make([]SliceKey, len(refs))
@@ -589,19 +601,12 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 		selection.Slices[i] = release.Packages[key.Package].Slices[key.Slice]
 	}
 
-	// Derive the channel from 'default-track' for store packages without an
-	// explicit one. Note the release only defines a track, the risk is
-	// implicit. Done after ordering so essentials-included packages get their
-	// channel too.
+	// Only report the channels of the selected packages.
+	selection.Channels = make(map[string]string)
 	for _, slice := range selection.Slices {
-		pkg := release.Packages[slice.Package]
-		if pkg.Store == "" {
-			continue
+		if channel, ok := channels[slice.Package]; ok {
+			selection.Channels[slice.Package] = channel
 		}
-		if _, ok := selection.Channels[pkg.Name]; ok {
-			continue
-		}
-		selection.Channels[pkg.Name] = pkg.DefaultTrack + "/" + DefaultRisk
 	}
 
 	for _, new := range selection.Slices {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
 
 	"golang.org/x/crypto/openpgp/packet"
 
@@ -145,17 +146,23 @@ func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	return apacheutil.ParseSliceKey(sliceKey)
 }
 
-// SliceRef is a slice reference with an optional track suffix for store
-// packages.
+// DefaultRisk is used when a channel does not specify a risk.
+const DefaultRisk = "stable"
+
+// SliceRef is a slice reference with an optional channel for store packages.
+// The channel always holds a risk, that is at least "<track>/<risk>".
 type SliceRef struct {
-	Key   SliceKey
-	Track string
+	Key     SliceKey
+	Channel string
 }
 
-// ParseSliceRef parses a "pkg_slice[@track]" reference. The track, if
-// present, must be non-empty and must not contain '/'.
+// ParseSliceRef parses a "pkg_slice[@channel]" reference. The channel is
+// either a track, in which case the default risk is used, or a
+// "<track>/<risk>" value. Validation is intentionally loose so that longer
+// channel forms, such as "<track>/<risk>/<branch>", are accepted without
+// changes here.
 func ParseSliceRef(ref string) (SliceRef, error) {
-	keyPart, track, ok := strings.Cut(ref, "@")
+	keyPart, channel, ok := strings.Cut(ref, "@")
 	if !ok {
 		key, err := ParseSliceKey(ref)
 		if err != nil {
@@ -167,13 +174,32 @@ func ParseSliceRef(ref string) (SliceRef, error) {
 	if err != nil {
 		return SliceRef{}, err
 	}
-	if track == "" {
-		return SliceRef{}, fmt.Errorf("invalid slice reference %q: missing track", ref)
+	channel, err = parseChannel(channel)
+	if err != nil {
+		return SliceRef{}, fmt.Errorf("invalid slice reference %q: %s", ref, err)
 	}
-	if strings.Contains(track, "/") {
-		return SliceRef{}, fmt.Errorf("invalid slice reference %q: track must not contain /", ref)
+	return SliceRef{Key: key, Channel: channel}, nil
+}
+
+// parseChannel validates a channel and returns it with the default risk
+// appended if it holds a track alone. Any number of segments is accepted so
+// that longer forms are not rejected here.
+func parseChannel(channel string) (string, error) {
+	if channel == "" {
+		return "", fmt.Errorf("missing channel")
 	}
-	return SliceRef{Key: key, Track: track}, nil
+	if strings.ContainsFunc(channel, unicode.IsSpace) {
+		return "", fmt.Errorf("channel must not contain spaces")
+	}
+	segments := strings.Split(channel, "/")
+	if slices.Contains(segments, "") {
+		return "", fmt.Errorf("channel must be <track> or <track>/<risk>")
+	}
+	if len(segments) == 1 {
+		// A track alone, the risk is implicit.
+		return channel + "/" + DefaultRisk, nil
+	}
+	return channel, nil
 }
 
 func (s *Slice) String() string { return s.Package + "_" + s.Name }
@@ -185,8 +211,8 @@ func (s *Slice) String() string { return s.Package + "_" + s.Name }
 type Selection struct {
 	Release *Release
 	Slices  []*Slice
-	// Tracks holds the resolved track per store package name.
-	Tracks map[string]string
+	// Channels holds the resolved channel per store package name.
+	Channels map[string]string
 }
 
 // Prefers uses the prefer relationships and returns a map from each path to
@@ -539,15 +565,15 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 		return nil, err
 	}
 
-	// Resolve the track per store package from the references.
-	tracks, err := resolveTracks(release, refs)
+	// Resolve the channel per store package from the references.
+	channels, err := resolveChannels(release, refs)
 	if err != nil {
 		return nil, err
 	}
 
 	selection := &Selection{
-		Release: release,
-		Tracks:  tracks,
+		Release:  release,
+		Channels: channels,
 	}
 
 	slices := make([]SliceKey, len(refs))
@@ -563,17 +589,19 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 		selection.Slices[i] = release.Packages[key.Package].Slices[key.Slice]
 	}
 
-	// Fill in the default-track for store packages without an explicit track.
-	// Done after ordering so essentials-included packages get their track too.
+	// Derive the channel from 'default-track' for store packages without an
+	// explicit one. Note the release only defines a track, the risk is
+	// implicit. Done after ordering so essentials-included packages get their
+	// channel too.
 	for _, slice := range selection.Slices {
 		pkg := release.Packages[slice.Package]
 		if pkg.Store == "" {
 			continue
 		}
-		if _, ok := selection.Tracks[pkg.Name]; ok {
+		if _, ok := selection.Channels[pkg.Name]; ok {
 			continue
 		}
-		selection.Tracks[pkg.Name] = pkg.DefaultTrack
+		selection.Channels[pkg.Name] = pkg.DefaultTrack + "/" + DefaultRisk
 	}
 
 	for _, new := range selection.Slices {
@@ -607,11 +635,11 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 	return selection, nil
 }
 
-// resolveTracks collects the explicit track per store package from the
-// references. It errors if a track is set on a non-store package or if two
-// references to the same package specify different tracks.
-func resolveTracks(release *Release, refs []SliceRef) (map[string]string, error) {
-	tracks := make(map[string]string)
+// resolveChannels collects the explicit channel per store package from the
+// references. It errors if a channel is set on a non-store package or if two
+// references to the same package specify different channels.
+func resolveChannels(release *Release, refs []SliceRef) (map[string]string, error) {
+	channels := make(map[string]string)
 	for _, ref := range refs {
 		pkg, ok := release.Packages[ref.Key.Package]
 		if !ok {
@@ -619,22 +647,22 @@ func resolveTracks(release *Release, refs []SliceRef) (map[string]string, error)
 			continue
 		}
 		if pkg.Store == "" {
-			if ref.Track != "" {
-				return nil, fmt.Errorf("slice %s has track but package %q is not in a store",
+			if ref.Channel != "" {
+				return nil, fmt.Errorf("slice %s has channel but package %q is not in a store",
 					ref.Key, pkg.Name)
 			}
 			continue
 		}
-		if ref.Track == "" {
+		if ref.Channel == "" {
 			continue
 		}
-		if existing, ok := tracks[pkg.Name]; ok && existing != ref.Track {
-			return nil, fmt.Errorf("slices of package %q have conflicting tracks %q and %q",
-				pkg.Name, existing, ref.Track)
+		if existing, ok := channels[pkg.Name]; ok && existing != ref.Channel {
+			return nil, fmt.Errorf("slices of package %q have conflicting channels %q and %q",
+				pkg.Name, existing, ref.Channel)
 		}
-		tracks[pkg.Name] = ref.Track
+		channels[pkg.Name] = ref.Channel
 	}
-	return tracks, nil
+	return channels, nil
 }
 
 const (

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -152,8 +152,8 @@ const DefaultRisk = "stable"
 // SliceRef is a slice reference with an optional channel for store packages.
 // The channel always holds a risk, that is at least "<track>/<risk>".
 type SliceRef struct {
-	Key     SliceKey
-	Channel string
+	SliceKey SliceKey
+	Channel  string
 }
 
 // ParseSliceRef parses a "pkg_slice[@channel]" reference. The channel is
@@ -164,13 +164,13 @@ type SliceRef struct {
 func ParseSliceRef(ref string) (SliceRef, error) {
 	keyPart, channel, ok := strings.Cut(ref, "@")
 	if !ok {
-		key, err := ParseSliceKey(ref)
+		sliceKey, err := ParseSliceKey(ref)
 		if err != nil {
 			return SliceRef{}, err
 		}
-		return SliceRef{Key: key}, nil
+		return SliceRef{SliceKey: sliceKey}, nil
 	}
-	key, err := ParseSliceKey(keyPart)
+	sliceKey, err := ParseSliceKey(keyPart)
 	if err != nil {
 		return SliceRef{}, err
 	}
@@ -178,7 +178,7 @@ func ParseSliceRef(ref string) (SliceRef, error) {
 	if err != nil {
 		return SliceRef{}, fmt.Errorf("invalid slice reference %q: %s", ref, err)
 	}
-	return SliceRef{Key: key, Channel: channel}, nil
+	return SliceRef{SliceKey: sliceKey, Channel: channel}, nil
 }
 
 // validateChannel returns the channel with the default risk appended if it
@@ -590,7 +590,7 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 
 	slices := make([]SliceKey, len(refs))
 	for i, ref := range refs {
-		slices[i] = ref.Key
+		slices[i] = ref.SliceKey
 	}
 	sorted, err := order(release.Packages, slices, arch)
 	if err != nil {
@@ -646,7 +646,7 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 func resolveChannels(release *Release, refs []SliceRef) (map[string]string, error) {
 	channels := make(map[string]string)
 	for _, ref := range refs {
-		pkg, ok := release.Packages[ref.Key.Package]
+		pkg, ok := release.Packages[ref.SliceKey.Package]
 		if !ok {
 			// Nothing to validate; the package is unknown.
 			continue
@@ -654,7 +654,7 @@ func resolveChannels(release *Release, refs []SliceRef) (map[string]string, erro
 		if pkg.Store == "" {
 			if ref.Channel != "" {
 				return nil, fmt.Errorf("slice %s has channel but package %q is not in a store",
-					ref.Key, pkg.Name)
+					ref.SliceKey, pkg.Name)
 			}
 			continue
 		}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -573,9 +573,6 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 		if _, ok := selection.Tracks[pkg.Name]; ok {
 			continue
 		}
-		if selection.Tracks == nil {
-			selection.Tracks = make(map[string]string)
-		}
 		selection.Tracks[pkg.Name] = pkg.DefaultTrack
 	}
 
@@ -612,14 +609,13 @@ func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) 
 
 // resolveTracks collects the explicit track per store package from the
 // references. It errors if a track is set on a non-store package or if two
-// references to the same package specify different tracks. Default-track
-// fallback is applied later by Select, once the full selection is known.
+// references to the same package specify different tracks.
 func resolveTracks(release *Release, refs []SliceRef) (map[string]string, error) {
-	var tracks map[string]string
+	tracks := make(map[string]string)
 	for _, ref := range refs {
 		pkg, ok := release.Packages[ref.Key.Package]
 		if !ok {
-			// Package existence is reported later by order().
+			// Nothing to validate; the package is unknown.
 			continue
 		}
 		if pkg.Store == "" {
@@ -635,9 +631,6 @@ func resolveTracks(release *Release, refs []SliceRef) (map[string]string, error)
 		if existing, ok := tracks[pkg.Name]; ok && existing != ref.Track {
 			return nil, fmt.Errorf("slices of package %q have conflicting tracks %q and %q",
 				pkg.Name, existing, ref.Track)
-		}
-		if tracks == nil {
-			tracks = make(map[string]string)
 		}
 		tracks[pkg.Name] = ref.Track
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -174,17 +174,17 @@ func ParseSliceRef(ref string) (SliceRef, error) {
 	if err != nil {
 		return SliceRef{}, err
 	}
-	channel, err = parseChannel(channel)
+	channel, err = validateChannel(channel)
 	if err != nil {
 		return SliceRef{}, fmt.Errorf("invalid slice reference %q: %s", ref, err)
 	}
 	return SliceRef{Key: key, Channel: channel}, nil
 }
 
-// parseChannel validates a channel and returns it with the default risk
-// appended if it holds a track alone. Any number of segments is accepted so
-// that longer forms are not rejected here.
-func parseChannel(channel string) (string, error) {
+// validateChannel returns the channel with the default risk appended if it
+// holds a track alone. Validation is intentionally loose, any number of
+// segments is accepted so that longer forms are not rejected here.
+func validateChannel(channel string) (string, error) {
 	if channel == "" {
 		return "", fmt.Errorf("missing channel")
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -145,6 +145,37 @@ func ParseSliceKey(sliceKey string) (SliceKey, error) {
 	return apacheutil.ParseSliceKey(sliceKey)
 }
 
+// SliceRef is a slice reference with an optional track suffix for store
+// packages.
+type SliceRef struct {
+	Key   SliceKey
+	Track string
+}
+
+// ParseSliceRef parses a "pkg_slice[@track]" reference. The track, if
+// present, must be non-empty and must not contain '/'.
+func ParseSliceRef(ref string) (SliceRef, error) {
+	keyPart, track, ok := strings.Cut(ref, "@")
+	if !ok {
+		key, err := ParseSliceKey(ref)
+		if err != nil {
+			return SliceRef{}, err
+		}
+		return SliceRef{Key: key}, nil
+	}
+	key, err := ParseSliceKey(keyPart)
+	if err != nil {
+		return SliceRef{}, err
+	}
+	if track == "" {
+		return SliceRef{}, fmt.Errorf("invalid slice reference %q: missing track", ref)
+	}
+	if strings.Contains(track, "/") {
+		return SliceRef{}, fmt.Errorf("invalid slice reference %q: track must not contain /", ref)
+	}
+	return SliceRef{Key: key, Track: track}, nil
+}
+
 func (s *Slice) String() string { return s.Package + "_" + s.Name }
 
 // Selection holds the required configuration to create a Build for a selection
@@ -154,6 +185,8 @@ func (s *Slice) String() string { return s.Package + "_" + s.Name }
 type Selection struct {
 	Release *Release
 	Slices  []*Slice
+	// Tracks holds the resolved track per store package name.
+	Tracks map[string]string
 }
 
 // Prefers uses the prefer relationships and returns a map from each path to
@@ -493,7 +526,7 @@ func stripBase(baseDir, path string) string {
 	return strings.TrimPrefix(path, baseDir+string(filepath.Separator))
 }
 
-func Select(release *Release, slices []SliceKey, arch string) (*Selection, error) {
+func Select(release *Release, refs []SliceRef, arch string) (*Selection, error) {
 	logf("Selecting slices...")
 
 	var err error
@@ -506,10 +539,21 @@ func Select(release *Release, slices []SliceKey, arch string) (*Selection, error
 		return nil, err
 	}
 
-	selection := &Selection{
-		Release: release,
+	// Resolve the track per store package from the references.
+	tracks, err := resolveTracks(release, refs)
+	if err != nil {
+		return nil, err
 	}
 
+	selection := &Selection{
+		Release: release,
+		Tracks:  tracks,
+	}
+
+	slices := make([]SliceKey, len(refs))
+	for i, ref := range refs {
+		slices[i] = ref.Key
+	}
 	sorted, err := order(release.Packages, slices, arch)
 	if err != nil {
 		return nil, err
@@ -517,6 +561,22 @@ func Select(release *Release, slices []SliceKey, arch string) (*Selection, error
 	selection.Slices = make([]*Slice, len(sorted))
 	for i, key := range sorted {
 		selection.Slices[i] = release.Packages[key.Package].Slices[key.Slice]
+	}
+
+	// Fill in the default-track for store packages without an explicit track.
+	// Done after ordering so essentials-included packages get their track too.
+	for _, slice := range selection.Slices {
+		pkg := release.Packages[slice.Package]
+		if pkg.Store == "" {
+			continue
+		}
+		if _, ok := selection.Tracks[pkg.Name]; ok {
+			continue
+		}
+		if selection.Tracks == nil {
+			selection.Tracks = make(map[string]string)
+		}
+		selection.Tracks[pkg.Name] = pkg.DefaultTrack
 	}
 
 	for _, new := range selection.Slices {
@@ -548,6 +608,40 @@ func Select(release *Release, slices []SliceKey, arch string) (*Selection, error
 	}
 
 	return selection, nil
+}
+
+// resolveTracks collects the explicit track per store package from the
+// references. It errors if a track is set on a non-store package or if two
+// references to the same package specify different tracks. Default-track
+// fallback is applied later by Select, once the full selection is known.
+func resolveTracks(release *Release, refs []SliceRef) (map[string]string, error) {
+	var tracks map[string]string
+	for _, ref := range refs {
+		pkg, ok := release.Packages[ref.Key.Package]
+		if !ok {
+			// Package existence is reported later by order().
+			continue
+		}
+		if pkg.Store == "" {
+			if ref.Track != "" {
+				return nil, fmt.Errorf("slice %s has track but package %q is not in a store",
+					ref.Key, pkg.Name)
+			}
+			continue
+		}
+		if ref.Track == "" {
+			continue
+		}
+		if existing, ok := tracks[pkg.Name]; ok && existing != ref.Track {
+			return nil, fmt.Errorf("slices of package %q have conflicting tracks %q and %q",
+				pkg.Name, existing, ref.Track)
+		}
+		if tracks == nil {
+			tracks = make(map[string]string)
+		}
+		tracks[pkg.Name] = ref.Track
+	}
+	return tracks, nil
 }
 
 const (

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -4442,6 +4442,40 @@ var setupTests = []setupTest{{
 		Channels: map[string]setup.Channel{"bin-mypkg": {Track: "3.0", Risk: "stable"}},
 	},
 }, {
+	summary: "Channels of unselected bin packages are not reported",
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
+		"bin-slices/mypkg.yaml": `
+			package: mypkg
+			store: bin
+			default-track: "3.0"
+			slices:
+				myslice:
+					contents:
+						/dir/file: {}
+		`,
+		"bin-slices/otherpkg.yaml": `
+			package: otherpkg
+			store: bin
+			default-track: "9.9"
+			slices:
+				myslice:
+					contents:
+						/other/file: {}
+		`,
+	},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "bin-mypkg",
+			Name:    "myslice",
+			Contents: map[string]setup.PathInfo{
+				"/dir/file": {Kind: setup.CopyPath},
+			},
+		}},
+		Channels: map[string]setup.Channel{"bin-mypkg": {Track: "3.0", Risk: "stable"}},
+	},
+}, {
 	summary: "Channel on bin slice is set from the reference",
 	selrefs: []setup.SliceRef{{
 		SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -26,7 +26,7 @@ type setupTest struct {
 	release   *setup.Release
 	relerror  string
 	prefers   map[string]string
-	selslices []setup.SliceKey
+	selrefs   []setup.SliceRef
 	selection *setup.Selection
 	selerror  string
 }
@@ -426,7 +426,7 @@ var setupTests = []setupTest{{
 				myslice2: {essential: [mypkg1_myslice1]}
 		`,
 	},
-	selslices: []setup.SliceKey{{"mypkg1", "myslice1"}},
+	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg1", "myslice1"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg1",
@@ -449,7 +449,7 @@ var setupTests = []setupTest{{
 				myslice2: {essential: [mypkg1_myslice1]}
 		`,
 	},
-	selslices: []setup.SliceKey{{"mypkg2", "myslice2"}},
+	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg2", "myslice2"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg1",
@@ -488,7 +488,11 @@ var setupTests = []setupTest{{
 						/path3: {symlink: /link}
 		`,
 	},
-	selslices: []setup.SliceKey{{"mypkg1", "myslice1"}, {"mypkg1", "myslice2"}, {"mypkg2", "myslice1"}},
+	selrefs: []setup.SliceRef{
+		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
+		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
+		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
+	},
 }, {
 	summary: "Conflicting paths across slices",
 	input: map[string]string{
@@ -1756,7 +1760,7 @@ var setupTests = []setupTest{{
 			EndOfLife: time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 	},
-	selslices: []setup.SliceKey{{"mypkg", "myslice"}},
+	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg",
@@ -1810,8 +1814,8 @@ var setupTests = []setupTest{{
 			EndOfLife: time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 	},
-	selslices: []setup.SliceKey{{"mypkg", "myslice"}},
-	selerror:  `slice mypkg_myslice has invalid 'generate' for path /dir/\*\*: "foo"`,
+	selrefs:  []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}},
+	selerror: `slice mypkg_myslice has invalid 'generate' for path /dir/\*\*: "foo"`,
 }, {
 	summary: "Paths with generate: manifest must have trailing /**",
 	input: map[string]string{
@@ -2430,11 +2434,11 @@ var setupTests = []setupTest{{
 	relerror: "slice mypkg1_myslice1 cannot 'prefer' its own package for path /file",
 }, {
 	summary: "Path conflicts with 'prefer'",
-	selslices: []setup.SliceKey{
-		{"mypkg1", "myslice1"},
-		{"mypkg1", "myslice2"},
-		{"mypkg2", "myslice1"},
-		{"mypkg3", "myslice1"},
+	selrefs: []setup.SliceRef{
+		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
+		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
+		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
+		{Key: setup.SliceKey{"mypkg3", "myslice1"}},
 	},
 	input: map[string]string{
 		"slices/mydir/mypkg1.yaml": `
@@ -2540,10 +2544,10 @@ var setupTests = []setupTest{{
 	},
 }, {
 	summary: "Path conflicts with 'prefer' depends on selection",
-	selslices: []setup.SliceKey{
-		{"mypkg1", "myslice1"},
-		{"mypkg1", "myslice2"},
-		{"mypkg2", "myslice1"},
+	selrefs: []setup.SliceRef{
+		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
+		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
+		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
 	},
 	input: map[string]string{
 		"slices/mydir/mypkg1.yaml": `
@@ -4374,8 +4378,8 @@ var setupTests = []setupTest{{
 		},
 	},
 }, {
-	summary:   "Store unknown kind",
-	selslices: []setup.SliceKey{{Package: "bin-mypkg", Slice: "myslice"}},
+	summary: "Store unknown kind",
+	selrefs: []setup.SliceRef{{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
 	input: map[string]string{
 		"chisel.yaml": `
 			format: v3
@@ -4409,6 +4413,135 @@ var setupTests = []setupTest{{
 		`,
 	},
 	selerror: `slice bin-mypkg_myslice refers to store "bin" with unknown kind "unknown"`,
+}, {
+	summary: "Track on bin slice uses default-track when omitted",
+	selrefs: []setup.SliceRef{{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
+		"bin-slices/mypkg.yaml": `
+			package: mypkg
+			store: bin
+			default-track: "3.0"
+			slices:
+				myslice:
+					contents:
+						/dir/file: {}
+		`,
+	},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "bin-mypkg",
+			Name:    "myslice",
+			Contents: map[string]setup.PathInfo{
+				"/dir/file": {Kind: setup.CopyPath},
+			},
+		}},
+		Tracks: map[string]string{"bin-mypkg": "3.0"},
+	},
+}, {
+	summary: "Track on bin slice is set from CLI reference",
+	selrefs: []setup.SliceRef{{
+		Key:   setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
+		Track: "2.0",
+	}},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
+		"bin-slices/mypkg.yaml": `
+			package: mypkg
+			store: bin
+			default-track: "3.0"
+			slices:
+				myslice:
+					contents:
+						/dir/file: {}
+		`,
+	},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "bin-mypkg",
+			Name:    "myslice",
+			Contents: map[string]setup.PathInfo{
+				"/dir/file": {Kind: setup.CopyPath},
+			},
+		}},
+		Tracks: map[string]string{"bin-mypkg": "2.0"},
+	},
+}, {
+	summary: "Same track on two slices of same bin package is allowed",
+	selrefs: []setup.SliceRef{
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Track: "2.0"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Track: "2.0"},
+	},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
+		"bin-slices/mypkg.yaml": `
+			package: mypkg
+			store: bin
+			default-track: "3.0"
+			slices:
+				myslice:
+					contents:
+						/dir/file1: {}
+				myslice2:
+					contents:
+						/dir/file2: {}
+		`,
+	},
+	selection: &setup.Selection{
+		Slices: []*setup.Slice{{
+			Package: "bin-mypkg",
+			Name:    "myslice",
+			Contents: map[string]setup.PathInfo{
+				"/dir/file1": {Kind: setup.CopyPath},
+			},
+		}, {
+			Package: "bin-mypkg",
+			Name:    "myslice2",
+			Contents: map[string]setup.PathInfo{
+				"/dir/file2": {Kind: setup.CopyPath},
+			},
+		}},
+		Tracks: map[string]string{"bin-mypkg": "2.0"},
+	},
+}, {
+	summary: "Conflicting tracks on two slices of same bin package fails",
+	selrefs: []setup.SliceRef{
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Track: "2.0"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Track: "3.0"},
+	},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
+		"bin-slices/mypkg.yaml": `
+			package: mypkg
+			store: bin
+			default-track: "3.0"
+			slices:
+				myslice:
+					contents:
+						/dir/file1: {}
+				myslice2:
+					contents:
+						/dir/file2: {}
+		`,
+	},
+	selerror: `slices of package "bin-mypkg" have conflicting tracks "2.0" and "3.0"`,
+}, {
+	summary: "Track on a non-store (deb) package fails",
+	selrefs: []setup.SliceRef{{
+		Key:   setup.SliceKey{Package: "mypkg", Slice: "myslice"},
+		Track: "2.0",
+	}},
+	input: map[string]string{
+		"chisel.yaml": testutil.DefaultChiselYaml,
+		"slices/mypkg.yaml": `
+			package: mypkg
+			slices:
+				myslice:
+					contents:
+						/dir/file: {}
+		`,
+	},
+	selerror: `slice mypkg_myslice has track but package "mypkg" is not in a store`,
 }}
 
 func (s *S) TestParseRelease(c *C) {
@@ -4540,8 +4673,8 @@ func runParseReleaseTests(c *C, tests []setupTest) {
 			c.Assert(release, DeepEquals, test.release)
 		}
 
-		if test.selslices != nil {
-			selection, err := setup.Select(release, test.selslices, "amd64")
+		if test.selrefs != nil {
+			selection, err := setup.Select(release, test.selrefs, "amd64")
 			if test.selerror != "" {
 				c.Assert(err, ErrorMatches, test.selerror)
 				continue
@@ -4907,8 +5040,8 @@ func (s *S) TestSelectEmptyArch(c *C) {
 	release, err := setup.ReadRelease(dir)
 	c.Assert(err, IsNil)
 
-	selslice := []setup.SliceKey{{"mypkg", "myslice"}}
-	selection, err := setup.Select(release, selslice, "")
+	refs := []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}}
+	selection, err := setup.Select(release, refs, "")
 	c.Assert(err, IsNil)
 
 	var sliceNames []string
@@ -4917,6 +5050,65 @@ func (s *S) TestSelectEmptyArch(c *C) {
 	}
 	expected := []string{"myotherslice", "myslice"}
 	c.Assert(sliceNames, DeepEquals, expected)
+}
+
+var parseSliceRefTests = []struct {
+	input    string
+	expected setup.SliceRef
+	err      string
+}{{
+	input:    "foo_bar",
+	expected: setup.SliceRef{Key: setup.SliceKey{Package: "foo", Slice: "bar"}},
+}, {
+	input: "foo_bar@3.0",
+	expected: setup.SliceRef{
+		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
+		Track: "3.0",
+	},
+}, {
+	input: "foo_bar@latest",
+	expected: setup.SliceRef{
+		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
+		Track: "latest",
+	},
+}, {
+	input: "foo-pkg_dashed-slice@3.0",
+	expected: setup.SliceRef{
+		Key:   setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
+		Track: "3.0",
+	},
+}, {
+	// Split on the first '@'; the track may itself contain '@'.
+	input: "foo_bar@3.0@x",
+	expected: setup.SliceRef{
+		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
+		Track: "3.0@x",
+	},
+}, {
+	input: "foo_bar@",
+	err:   `invalid slice reference "foo_bar@": missing track`,
+}, {
+	input: "foo_bar@3.0/stable",
+	err:   `invalid slice reference "foo_bar@3.0/stable": track must not contain /`,
+}, {
+	// Identity part is still validated by ParseSliceKey.
+	input: "foo_ba@3.0",
+	err:   `invalid slice reference: "foo_ba"`,
+}, {
+	input: "foo_bar_baz@3.0",
+	err:   `invalid slice reference: "foo_bar_baz"`,
+}}
+
+func (s *S) TestParseSliceRef(c *C) {
+	for _, test := range parseSliceRefTests {
+		ref, err := setup.ParseSliceRef(test.input)
+		if test.err != "" {
+			c.Assert(err, ErrorMatches, test.err)
+			continue
+		}
+		c.Assert(err, IsNil)
+		c.Assert(ref, DeepEquals, test.expected)
+	}
 }
 
 // oldEssentialToV3 converts the essentials in v1 and v2, both 'essential', and

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -432,7 +432,7 @@ var setupTests = []setupTest{{
 			Package: "mypkg1",
 			Name:    "myslice1",
 		}},
-		Tracks: map[string]string{},
+		Channels: map[string]string{},
 	},
 }, {
 	summary: "Selection with dependencies",
@@ -462,7 +462,7 @@ var setupTests = []setupTest{{
 				{"mypkg1", "myslice1"}: {},
 			},
 		}},
-		Tracks: map[string]string{},
+		Channels: map[string]string{},
 	},
 }, {
 	summary: "Selection with matching paths don't conflict",
@@ -1771,7 +1771,7 @@ var setupTests = []setupTest{{
 				"/dir/**": {Kind: "generate", Generate: "manifest"},
 			},
 		}},
-		Tracks: map[string]string{},
+		Channels: map[string]string{},
 	},
 }, {
 	summary: "Can specify generate with bogus value but cannot select those slices",
@@ -4417,7 +4417,7 @@ var setupTests = []setupTest{{
 	},
 	selerror: `slice bin-mypkg_myslice refers to store "bin" with unknown kind "unknown"`,
 }, {
-	summary: "Track on bin slice uses default-track when omitted",
+	summary: "Channel on bin slice is derived from default-track when omitted",
 	selrefs: []setup.SliceRef{{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4439,13 +4439,13 @@ var setupTests = []setupTest{{
 				"/dir/file": {Kind: setup.CopyPath},
 			},
 		}},
-		Tracks: map[string]string{"bin-mypkg": "3.0"},
+		Channels: map[string]string{"bin-mypkg": "3.0/stable"},
 	},
 }, {
-	summary: "Track on bin slice is set from CLI reference",
+	summary: "Channel on bin slice is set from the reference",
 	selrefs: []setup.SliceRef{{
-		Key:   setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
-		Track: "2.0",
+		Key:     setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
+		Channel: "2.0/edge",
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4467,13 +4467,13 @@ var setupTests = []setupTest{{
 				"/dir/file": {Kind: setup.CopyPath},
 			},
 		}},
-		Tracks: map[string]string{"bin-mypkg": "2.0"},
+		Channels: map[string]string{"bin-mypkg": "2.0/edge"},
 	},
 }, {
-	summary: "Same track on two slices of same bin package is allowed",
+	summary: "Same channel on two slices of same bin package is allowed",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Track: "2.0"},
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Track: "2.0"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/stable"},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4504,13 +4504,13 @@ var setupTests = []setupTest{{
 				"/dir/file2": {Kind: setup.CopyPath},
 			},
 		}},
-		Tracks: map[string]string{"bin-mypkg": "2.0"},
+		Channels: map[string]string{"bin-mypkg": "2.0/stable"},
 	},
 }, {
-	summary: "Conflicting tracks on two slices of same bin package fails",
+	summary: "Conflicting channels on two slices of same bin package fails",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Track: "2.0"},
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Track: "3.0"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
+		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/edge"},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4527,12 +4527,12 @@ var setupTests = []setupTest{{
 						/dir/file2: {}
 		`,
 	},
-	selerror: `slices of package "bin-mypkg" have conflicting tracks "2.0" and "3.0"`,
+	selerror: `slices of package "bin-mypkg" have conflicting channels "2.0/stable" and "2.0/edge"`,
 }, {
-	summary: "Track on a non-store (deb) package fails",
+	summary: "Channel on a non-store (deb) package fails",
 	selrefs: []setup.SliceRef{{
-		Key:   setup.SliceKey{Package: "mypkg", Slice: "myslice"},
-		Track: "2.0",
+		Key:     setup.SliceKey{Package: "mypkg", Slice: "myslice"},
+		Channel: "2.0/stable",
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYaml,
@@ -4544,7 +4544,7 @@ var setupTests = []setupTest{{
 						/dir/file: {}
 		`,
 	},
-	selerror: `slice mypkg_myslice has track but package "mypkg" is not in a store`,
+	selerror: `slice mypkg_myslice has channel but package "mypkg" is not in a store`,
 }}
 
 func (s *S) TestParseRelease(c *C) {
@@ -5063,36 +5063,73 @@ var parseSliceRefTests = []struct {
 	input:    "foo_bar",
 	expected: setup.SliceRef{Key: setup.SliceKey{Package: "foo", Slice: "bar"}},
 }, {
+	// A track alone gets the default risk.
 	input: "foo_bar@3.0",
 	expected: setup.SliceRef{
-		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
-		Track: "3.0",
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0/stable",
 	},
 }, {
 	input: "foo_bar@latest",
 	expected: setup.SliceRef{
-		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
-		Track: "latest",
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "latest/stable",
 	},
 }, {
-	input: "foo-pkg_dashed-slice@3.0",
+	input: "foo_bar@3.0/edge",
 	expected: setup.SliceRef{
-		Key:   setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
-		Track: "3.0",
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0/edge",
 	},
 }, {
-	// Split on the first '@'; the track may itself contain '@'.
+	// An explicit default risk is kept as is.
+	input: "foo_bar@3.0/stable",
+	expected: setup.SliceRef{
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0/stable",
+	},
+}, {
+	// Validation is loose, unknown risks are accepted.
+	input: "foo_bar@3.0/whatever",
+	expected: setup.SliceRef{
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0/whatever",
+	},
+}, {
+	input: "foo-pkg_dashed-slice@3.0/beta",
+	expected: setup.SliceRef{
+		Key:     setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
+		Channel: "3.0/beta",
+	},
+}, {
+	// Split on the first '@'; the channel may itself contain '@'.
 	input: "foo_bar@3.0@x",
 	expected: setup.SliceRef{
-		Key:   setup.SliceKey{Package: "foo", Slice: "bar"},
-		Track: "3.0@x",
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0@x/stable",
+	},
+}, {
+	// Longer forms, such as a branch, are not rejected.
+	input: "foo_bar@3.0/stable/mybranch",
+	expected: setup.SliceRef{
+		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel: "3.0/stable/mybranch",
 	},
 }, {
 	input: "foo_bar@",
-	err:   `invalid slice reference "foo_bar@": missing track`,
+	err:   `invalid slice reference "foo_bar@": missing channel`,
 }, {
-	input: "foo_bar@3.0/stable",
-	err:   `invalid slice reference "foo_bar@3.0/stable": track must not contain /`,
+	input: "foo_bar@/stable",
+	err:   `invalid slice reference "foo_bar@/stable": channel must be <track> or <track>/<risk>`,
+}, {
+	input: "foo_bar@3.0/",
+	err:   `invalid slice reference "foo_bar@3.0/": channel must be <track> or <track>/<risk>`,
+}, {
+	input: "foo_bar@3.0//stable",
+	err:   `invalid slice reference "foo_bar@3.0//stable": channel must be <track> or <track>/<risk>`,
+}, {
+	input: "foo_bar@3.0 stable",
+	err:   `invalid slice reference "foo_bar@3.0 stable": channel must not contain spaces`,
 }, {
 	// Identity part is still validated by ParseSliceKey.
 	input: "foo_ba@3.0",

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -432,6 +432,7 @@ var setupTests = []setupTest{{
 			Package: "mypkg1",
 			Name:    "myslice1",
 		}},
+		Tracks: map[string]string{},
 	},
 }, {
 	summary: "Selection with dependencies",
@@ -461,6 +462,7 @@ var setupTests = []setupTest{{
 				{"mypkg1", "myslice1"}: {},
 			},
 		}},
+		Tracks: map[string]string{},
 	},
 }, {
 	summary: "Selection with matching paths don't conflict",
@@ -1769,6 +1771,7 @@ var setupTests = []setupTest{{
 				"/dir/**": {Kind: "generate", Generate: "manifest"},
 			},
 		}},
+		Tracks: map[string]string{},
 	},
 }, {
 	summary: "Can specify generate with bogus value but cannot select those slices",

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -432,7 +432,7 @@ var setupTests = []setupTest{{
 			Package: "mypkg1",
 			Name:    "myslice1",
 		}},
-		Channels: map[string]string{},
+		Channels: map[string]setup.Channel{},
 	},
 }, {
 	summary: "Selection with dependencies",
@@ -462,7 +462,7 @@ var setupTests = []setupTest{{
 				{"mypkg1", "myslice1"}: {},
 			},
 		}},
-		Channels: map[string]string{},
+		Channels: map[string]setup.Channel{},
 	},
 }, {
 	summary: "Selection with matching paths don't conflict",
@@ -1771,7 +1771,7 @@ var setupTests = []setupTest{{
 				"/dir/**": {Kind: "generate", Generate: "manifest"},
 			},
 		}},
-		Channels: map[string]string{},
+		Channels: map[string]setup.Channel{},
 	},
 }, {
 	summary: "Can specify generate with bogus value but cannot select those slices",
@@ -4439,13 +4439,13 @@ var setupTests = []setupTest{{
 				"/dir/file": {Kind: setup.CopyPath},
 			},
 		}},
-		Channels: map[string]string{"bin-mypkg": "3.0/stable"},
+		Channels: map[string]setup.Channel{"bin-mypkg": {Track: "3.0", Risk: "stable"}},
 	},
 }, {
 	summary: "Channel on bin slice is set from the reference",
 	selrefs: []setup.SliceRef{{
 		SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
-		Channel:  "2.0/edge",
+		Channel:  setup.Channel{Track: "2.0", Risk: "edge"},
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4467,13 +4467,13 @@ var setupTests = []setupTest{{
 				"/dir/file": {Kind: setup.CopyPath},
 			},
 		}},
-		Channels: map[string]string{"bin-mypkg": "2.0/edge"},
+		Channels: map[string]setup.Channel{"bin-mypkg": {Track: "2.0", Risk: "edge"}},
 	},
 }, {
 	summary: "Same channel on two slices of same bin package is allowed",
 	selrefs: []setup.SliceRef{
-		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
-		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/stable"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: setup.Channel{Track: "2.0", Risk: "stable"}},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: setup.Channel{Track: "2.0", Risk: "stable"}},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4504,13 +4504,13 @@ var setupTests = []setupTest{{
 				"/dir/file2": {Kind: setup.CopyPath},
 			},
 		}},
-		Channels: map[string]string{"bin-mypkg": "2.0/stable"},
+		Channels: map[string]setup.Channel{"bin-mypkg": {Track: "2.0", Risk: "stable"}},
 	},
 }, {
 	summary: "Conflicting channels on two slices of same bin package fails",
 	selrefs: []setup.SliceRef{
-		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
-		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/edge"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: setup.Channel{Track: "2.0", Risk: "stable"}},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: setup.Channel{Track: "2.0", Risk: "edge"}},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4532,7 +4532,7 @@ var setupTests = []setupTest{{
 	summary: "Channel on a non-store (deb) package fails",
 	selrefs: []setup.SliceRef{{
 		SliceKey: setup.SliceKey{Package: "mypkg", Slice: "myslice"},
-		Channel:  "2.0/stable",
+		Channel:  setup.Channel{Track: "2.0", Risk: "stable"},
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYaml,
@@ -5067,66 +5067,73 @@ var parseSliceRefTests = []struct {
 	input: "foo_bar@3.0",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0/stable",
+		Channel:  setup.Channel{Track: "3.0", Risk: "stable"},
 	},
 }, {
 	input: "foo_bar@latest",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "latest/stable",
+		Channel:  setup.Channel{Track: "latest", Risk: "stable"},
 	},
 }, {
 	input: "foo_bar@3.0/edge",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0/edge",
+		Channel:  setup.Channel{Track: "3.0", Risk: "edge"},
 	},
 }, {
 	// An explicit default risk is kept as is.
 	input: "foo_bar@3.0/stable",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0/stable",
+		Channel:  setup.Channel{Track: "3.0", Risk: "stable"},
 	},
 }, {
 	// Validation is loose, unknown risks are accepted.
 	input: "foo_bar@3.0/whatever",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0/whatever",
+		Channel:  setup.Channel{Track: "3.0", Risk: "whatever"},
 	},
 }, {
 	input: "foo-pkg_dashed-slice@3.0/beta",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
-		Channel:  "3.0/beta",
+		Channel:  setup.Channel{Track: "3.0", Risk: "beta"},
 	},
 }, {
 	// Split on the first '@'; the channel may itself contain '@'.
 	input: "foo_bar@3.0@x",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0@x/stable",
+		Channel:  setup.Channel{Track: "3.0@x", Risk: "stable"},
 	},
 }, {
-	// Longer forms, such as a branch, are not rejected.
+	// A branch is accepted, although not advertised yet.
 	input: "foo_bar@3.0/stable/mybranch",
 	expected: setup.SliceRef{
 		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel:  "3.0/stable/mybranch",
+		Channel:  setup.Channel{Track: "3.0", Risk: "stable", Branch: "mybranch"},
 	},
 }, {
 	input: "foo_bar@",
 	err:   `invalid slice reference "foo_bar@": missing channel`,
 }, {
 	input: "foo_bar@/stable",
-	err:   `invalid slice reference "foo_bar@/stable": channel must be <track> or <track>/<risk>`,
+	err:   `invalid slice reference "foo_bar@/stable": channel must be <track>\[/<risk>\[/<branch>\]\]`,
 }, {
 	input: "foo_bar@3.0/",
-	err:   `invalid slice reference "foo_bar@3.0/": channel must be <track> or <track>/<risk>`,
+	err:   `invalid slice reference "foo_bar@3.0/": channel must be <track>\[/<risk>\[/<branch>\]\]`,
 }, {
 	input: "foo_bar@3.0//stable",
-	err:   `invalid slice reference "foo_bar@3.0//stable": channel must be <track> or <track>/<risk>`,
+	err:   `invalid slice reference "foo_bar@3.0//stable": channel must be <track>\[/<risk>\[/<branch>\]\]`,
+}, {
+	input: "foo_bar@3.0/stable/",
+	err:   `invalid slice reference "foo_bar@3.0/stable/": channel must be <track>\[/<risk>\[/<branch>\]\]`,
+}, {
+	// A branch must not contain a /, hence no more than three segments.
+	input: "foo_bar@3.0/stable/mybranch/extra",
+	err:   `invalid slice reference "foo_bar@3.0/stable/mybranch/extra": channel must be <track>\[/<risk>\[/<branch>\]\]`,
 }, {
 	input: "foo_bar@3.0 stable",
 	err:   `invalid slice reference "foo_bar@3.0 stable": channel must not contain spaces`,

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -426,7 +426,7 @@ var setupTests = []setupTest{{
 				myslice2: {essential: [mypkg1_myslice1]}
 		`,
 	},
-	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg1", "myslice1"}}},
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{"mypkg1", "myslice1"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg1",
@@ -450,7 +450,7 @@ var setupTests = []setupTest{{
 				myslice2: {essential: [mypkg1_myslice1]}
 		`,
 	},
-	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg2", "myslice2"}}},
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{"mypkg2", "myslice2"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg1",
@@ -491,9 +491,9 @@ var setupTests = []setupTest{{
 		`,
 	},
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
-		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
-		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice2"}},
+		{SliceKey: setup.SliceKey{"mypkg2", "myslice1"}},
 	},
 }, {
 	summary: "Conflicting paths across slices",
@@ -1762,7 +1762,7 @@ var setupTests = []setupTest{{
 			EndOfLife: time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 	},
-	selrefs: []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}},
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{"mypkg", "myslice"}}},
 	selection: &setup.Selection{
 		Slices: []*setup.Slice{{
 			Package: "mypkg",
@@ -1817,7 +1817,7 @@ var setupTests = []setupTest{{
 			EndOfLife: time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 	},
-	selrefs:  []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}},
+	selrefs:  []setup.SliceRef{{SliceKey: setup.SliceKey{"mypkg", "myslice"}}},
 	selerror: `slice mypkg_myslice has invalid 'generate' for path /dir/\*\*: "foo"`,
 }, {
 	summary: "Paths with generate: manifest must have trailing /**",
@@ -2438,10 +2438,10 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Path conflicts with 'prefer'",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
-		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
-		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
-		{Key: setup.SliceKey{"mypkg3", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice2"}},
+		{SliceKey: setup.SliceKey{"mypkg2", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg3", "myslice1"}},
 	},
 	input: map[string]string{
 		"slices/mydir/mypkg1.yaml": `
@@ -2548,9 +2548,9 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Path conflicts with 'prefer' depends on selection",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{"mypkg1", "myslice1"}},
-		{Key: setup.SliceKey{"mypkg1", "myslice2"}},
-		{Key: setup.SliceKey{"mypkg2", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice1"}},
+		{SliceKey: setup.SliceKey{"mypkg1", "myslice2"}},
+		{SliceKey: setup.SliceKey{"mypkg2", "myslice1"}},
 	},
 	input: map[string]string{
 		"slices/mydir/mypkg1.yaml": `
@@ -4382,7 +4382,7 @@ var setupTests = []setupTest{{
 	},
 }, {
 	summary: "Store unknown kind",
-	selrefs: []setup.SliceRef{{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
 	input: map[string]string{
 		"chisel.yaml": `
 			format: v3
@@ -4418,7 +4418,7 @@ var setupTests = []setupTest{{
 	selerror: `slice bin-mypkg_myslice refers to store "bin" with unknown kind "unknown"`,
 }, {
 	summary: "Channel on bin slice is derived from default-track when omitted",
-	selrefs: []setup.SliceRef{{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
+	selrefs: []setup.SliceRef{{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
 		"bin-slices/mypkg.yaml": `
@@ -4444,8 +4444,8 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Channel on bin slice is set from the reference",
 	selrefs: []setup.SliceRef{{
-		Key:     setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
-		Channel: "2.0/edge",
+		SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"},
+		Channel:  "2.0/edge",
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4472,8 +4472,8 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Same channel on two slices of same bin package is allowed",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/stable"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/stable"},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4509,8 +4509,8 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Conflicting channels on two slices of same bin package fails",
 	selrefs: []setup.SliceRef{
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
-		{Key: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/edge"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice"}, Channel: "2.0/stable"},
+		{SliceKey: setup.SliceKey{Package: "bin-mypkg", Slice: "myslice2"}, Channel: "2.0/edge"},
 	},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYamlWithStores,
@@ -4531,8 +4531,8 @@ var setupTests = []setupTest{{
 }, {
 	summary: "Channel on a non-store (deb) package fails",
 	selrefs: []setup.SliceRef{{
-		Key:     setup.SliceKey{Package: "mypkg", Slice: "myslice"},
-		Channel: "2.0/stable",
+		SliceKey: setup.SliceKey{Package: "mypkg", Slice: "myslice"},
+		Channel:  "2.0/stable",
 	}},
 	input: map[string]string{
 		"chisel.yaml": testutil.DefaultChiselYaml,
@@ -5043,7 +5043,7 @@ func (s *S) TestSelectEmptyArch(c *C) {
 	release, err := setup.ReadRelease(dir)
 	c.Assert(err, IsNil)
 
-	refs := []setup.SliceRef{{Key: setup.SliceKey{"mypkg", "myslice"}}}
+	refs := []setup.SliceRef{{SliceKey: setup.SliceKey{"mypkg", "myslice"}}}
 	selection, err := setup.Select(release, refs, "")
 	c.Assert(err, IsNil)
 
@@ -5061,59 +5061,59 @@ var parseSliceRefTests = []struct {
 	err      string
 }{{
 	input:    "foo_bar",
-	expected: setup.SliceRef{Key: setup.SliceKey{Package: "foo", Slice: "bar"}},
+	expected: setup.SliceRef{SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"}},
 }, {
 	// A track alone gets the default risk.
 	input: "foo_bar@3.0",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0/stable",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0/stable",
 	},
 }, {
 	input: "foo_bar@latest",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "latest/stable",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "latest/stable",
 	},
 }, {
 	input: "foo_bar@3.0/edge",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0/edge",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0/edge",
 	},
 }, {
 	// An explicit default risk is kept as is.
 	input: "foo_bar@3.0/stable",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0/stable",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0/stable",
 	},
 }, {
 	// Validation is loose, unknown risks are accepted.
 	input: "foo_bar@3.0/whatever",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0/whatever",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0/whatever",
 	},
 }, {
 	input: "foo-pkg_dashed-slice@3.0/beta",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
-		Channel: "3.0/beta",
+		SliceKey: setup.SliceKey{Package: "foo-pkg", Slice: "dashed-slice"},
+		Channel:  "3.0/beta",
 	},
 }, {
 	// Split on the first '@'; the channel may itself contain '@'.
 	input: "foo_bar@3.0@x",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0@x/stable",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0@x/stable",
 	},
 }, {
 	// Longer forms, such as a branch, are not rejected.
 	input: "foo_bar@3.0/stable/mybranch",
 	expected: setup.SliceRef{
-		Key:     setup.SliceKey{Package: "foo", Slice: "bar"},
-		Channel: "3.0/stable/mybranch",
+		SliceKey: setup.SliceKey{Package: "foo", Slice: "bar"},
+		Channel:  "3.0/stable/mybranch",
 	},
 }, {
 	input: "foo_bar@",

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -2094,7 +2094,11 @@ func runSlicerTests(s *S, c *C, tests []slicerTest) {
 				Slice:   "manifest",
 			})
 
-			selection, err := setup.Select(release, testSlices, test.arch)
+			refs := make([]setup.SliceRef, len(testSlices))
+			for i, key := range testSlices {
+				refs[i] = setup.SliceRef{Key: key}
+			}
+			selection, err := setup.Select(release, refs, test.arch)
 			c.Assert(err, IsNil)
 
 			archives := map[string]archive.Archive{}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -2096,7 +2096,7 @@ func runSlicerTests(s *S, c *C, tests []slicerTest) {
 
 			refs := make([]setup.SliceRef, len(testSlices))
 			for i, key := range testSlices {
-				refs[i] = setup.SliceRef{Key: key}
+				refs[i] = setup.SliceRef{SliceKey: key}
 			}
 			selection, err := setup.Select(release, refs, test.arch)
 			c.Assert(err, IsNil)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Allow selecting a channel when cutting slices from store packages (bins), via a `pkg_slice@channel` suffix on the command line.

Unlike debs, bins are published per channel, so users need to pick which one to fetch; a bare `@3.0` is treated as a track and gets the default risk (`stable`), while `@3.0/edge` is used as given. When no suffix is provided, the channel is derived from the package's `default-track` in the slice definition, which stays a track — the risk remains implicit on the YAML side. The channel is kept strictly separate from slice identity: it flows only from the reference through `setup.Select` into `Selection.Channels` for the slicer to consume at fetch time, leaving dependency resolution, conflict checks and the manifest untouched. Conflicting channels for slices of the same package and channels on non-store packages are rejected, `info`/`find` commands reject the `@` suffix since it is only meaningful when cutting, and channel validation is intentionally loose so longer forms such as `track/risk/branch` are not rejected today.

NOTE: This PR only prepares a Channels map in the Selection. Subsequent work to fetch bins from the store will consume it to get the right revision.