### PR TITLE
feat: custom repositories.

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -91,6 +91,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 			PubKeys:    archiveInfo.PubKeys,
 			Maintained: archiveInfo.Maintained,
 			OldRelease: archiveInfo.OldRelease,
+			Url:        archiveInfo.Url,
 		})
 		if err != nil {
 			if err == archive.ErrCredentialsNotFound {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -46,6 +46,8 @@ type Options struct {
 	// OldRelease is set for Ubuntu releases which are moved from the regular
 	// archive which happens after the release's end of life date.
 	OldRelease bool
+	// Custom url for an archive. Can't be used with 'Pro', probably.
+	Url string
 }
 
 func Open(options *Options) (Archive, error) {
@@ -223,10 +225,23 @@ func openUbuntu(options *Options) (Archive, error) {
 	if len(options.Version) == 0 {
 		return nil, fmt.Errorf("archive options missing version")
 	}
+	var baseURL string
+	var creds *credentials
 
-	baseURL, creds, err := archiveURL(options.Pro, options.Arch, options.OldRelease)
-	if err != nil {
-		return nil, err
+	if options.Url == "" {
+		var err error
+		baseURL, creds, err = archiveURL(options.Pro, options.Arch, options.OldRelease)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if strings.HasPrefix(options.Url, "http://") ||
+			strings.HasPrefix(options.Url, "https://") {
+			baseURL = options.Url
+			creds = nil
+		} else {
+			return nil, fmt.Errorf("archive url should start with http:// or https://. Got %q", options.Url)
+		}
 	}
 
 	archive := &ubuntuArchive{
@@ -317,6 +332,10 @@ func (index *ubuntuIndex) fetchRelease() error {
 	label := "Ubuntu"
 	if index.archive.options.Pro != "" {
 		label = proArchiveInfo[index.archive.options.Pro].Label
+	}
+	// Custom archive name must match it's label
+	if index.archive.options.Url != "" {
+		label = index.archive.options.Label
 	}
 	section := ctrl.Section(label)
 	if section == nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -56,6 +56,7 @@ type Archive struct {
 	// OldRelease is set for Ubuntu releases which are moved from the regular
 	// archive which happens after the release's end of life date.
 	OldRelease bool
+	Url        string
 }
 
 // Package holds a collection of slices that represent parts of themselves.

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -51,6 +51,7 @@ type yamlArchive struct {
 	Pro        string   `yaml:"pro"`
 	Default    bool     `yaml:"default"`
 	PubKeys    []string `yaml:"public-keys"`
+	Url        string   `yaml:"url"`
 }
 
 type yamlStore struct {
@@ -371,6 +372,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Pro:        details.Pro,
 			Priority:   priority,
 			PubKeys:    archiveKeys,
+			Url:        details.Url,
 		}
 	}
 	if (hasPriority && archiveNoPriority != "") ||


### PR DESCRIPTION
This PR adds (rather crude) support for third party repositories.

I'm trying to build a custom image for nginx (and later - nginx-plus).
Chisel seems like a good tool for the task. But it doesn't support third party repositories.

To work around this issue I added 'url' field into chisel.yaml. This allows one to add an archive like this:
```
  nginx:
    priority: 20
    version: 24.04
    components: [nginx]
    suites: [noble]
    public-keys: [nginx-key]
    url: https://packages.nginx.org/nginx/mainline/ubuntu/
```
And then add some slices into chisel-release to install from the new repository.
I'm not sure if I have to bump any versions. I would appreciate help with this. 

-----
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?


